### PR TITLE
Handle tox dependencies through extras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,11 @@
 # Use podman-compose by default if available.
 ifeq (, $(shell which podman-compose))
     COMPOSE := docker-compose
-    PODMAN := docker
 else
     COMPOSE := podman-compose
-    PODMAN := podman
 endif
 
-BROWSER := xdg-open
-SERVICE := dev
-
-PYTHON_VERSION_VENV := python3.9
-
-POETRY_RUN := poetry run
-PYTEST := pytest --color=yes
-PIP_INSTALL := pip3 install --no-cache-dir --user
+TOX := tox
 
 all: help
 
@@ -29,15 +20,7 @@ help:
 	@echo
 	@echo '  make recreate - recreates containers for docker-compose environment'
 	@echo
-	@echo '  make exec [CMD=".."] - executes command in dev container'
-	@echo
-	@echo '  make sudo [CMD=".."] - executes command in dev container under root user'
-	@echo
-	@echo '  make pytest [ARGS=".."] - executes pytest with given arguments in dev container'
-	@echo
-	@echo '  make test - alias for "make pytest"'
-	@echo
-	@echo '  make coverage [ARGS=".."] - generates and shows test code coverage'
+	@echo '  make test - run unit and functional tests'
 	@echo
 	@echo 'Variables:'
 	@echo
@@ -45,13 +28,8 @@ help:
 	@echo '    - docker-compose or podman-compose command'
 	@echo '      (default is "podman-compose" if available)'
 	@echo
-	@echo '  PODMAN=docker|podman'
-	@echo '    - docker or podman command'
-	@echo '      (default is "podman" if "podman-compose" is available)'
-	@echo
-	@echo '  SERVICE={dev|waiverdb|resultsdb|waiverdb-db|resultsdb-db|memcached}'
-	@echo '    - service for which to run `make exec` and similar (default is "dev")'
-	@echo '      Example: make exec SERVICE=waiverdb CMD=flake8'
+	@echo '  ARGS=""'
+	@echo '    - additional arguments for pytest'
 
 up:
 	$(COMPOSE) up -d
@@ -65,21 +43,5 @@ build:
 recreate:
 	$(COMPOSE) up -d --force-recreate
 
-exec:
-	$(PODMAN) exec greenwave_$(SERVICE)_1 bash -c '$(CMD)'
-
-sudo:
-	$(PODMAN) exec -u root greenwave_$(SERVICE)_1 bash -c '$(CMD)'
-
 test:
-	$(MAKE) exec CMD="$(PIP_INSTALL) poetry"
-	$(MAKE) exec CMD="poetry install --no-root"
-	$(MAKE) pytest
-
-pytest:
-	$(MAKE) exec \
-	    CMD="COVERAGE_FILE=/home/dev/.coverage-$(SERVICE) $(POETRY_RUN) $(PYTEST) $(ARGS)"
-
-coverage:
-	$(MAKE) pytest ARGS="--cov-config .coveragerc --cov=greenwave --cov-report html:/home/dev/htmlcov-$(SERVICE) $(ARGS)"
-	$(BROWSER) docker/home/htmlcov-$(SERVICE)/index.html
+	$(TOX) -e functional -- $(ARGS)

--- a/docs/docker-compose.rst
+++ b/docs/docker-compose.rst
@@ -63,7 +63,7 @@ Run a specific test:
 
 .. code-block:: console
 
-  make pytest ARGS="-vv -x greenwave/tests/test_rules.py -k test_remote_rule
+  make test ARGS="-vv -x greenwave/tests/test_rules.py -k test_remote_rule
 
 Stop the containers:
 

--- a/functional-tests/test_api_v1.py
+++ b/functional-tests/test_api_v1.py
@@ -23,6 +23,19 @@ OPENQA_SCENARIOS = [
 ]
 
 
+def drop_href(obj):
+    if isinstance(obj, dict):
+        return {
+            k: drop_href(v) for k, v in obj.items()
+            if k != "href"
+        }
+    return obj
+
+
+def drop_hrefs(results):
+    return [drop_href(result) for result in results]
+
+
 @pytest.mark.smoke
 def test_any_policies_loaded(requests_session, greenwave_server):
     r = requests_session.get(greenwave_server + 'api/v1.0/policies',
@@ -249,7 +262,7 @@ def test_make_a_decision_with_verbose_flag(requests_session, greenwave_server, t
     res_data = r.json()
 
     assert len(res_data['results']) == len(TASKTRON_RELEASE_CRITICAL_TASKS)
-    assert res_data['results'] == list(reversed(results))
+    assert drop_hrefs(res_data['results']) == drop_hrefs(list(reversed(results)))
     expected_waivers = []
     assert res_data['waivers'] == expected_waivers
 
@@ -294,7 +307,7 @@ def test_make_a_decision_with_verbose_flag_and_multiple_nvrs_with_results(
     res_data = r.json()
 
     assert len(res_data['results']) == len(TASKTRON_RELEASE_CRITICAL_TASKS) * len(build_nvrs)
-    assert res_data['results'] == list(reversed(results))
+    assert drop_hrefs(res_data['results']) == drop_hrefs(list(reversed(results)))
 
 
 def test_make_a_decision_with_verbose_flag_and_multiple_nvrs_with_waivers(
@@ -1278,7 +1291,7 @@ def test_make_a_decision_for_bodhi_with_verbose_flag(
     res_data = r.json()
 
     assert len(res_data['results']) == len(TASKTRON_RELEASE_CRITICAL_TASKS) * len(nvrs)
-    assert res_data['results'] == list(reversed(results))
+    assert drop_hrefs(res_data['results']) == drop_hrefs(list(reversed(results)))
     assert res_data['waivers'] == []
     assert res_data['satisfied_requirements'] == []
 
@@ -1403,7 +1416,7 @@ def test_make_a_decision_with_verbose_flag_all_results_returned(
     res_data = r.json()
 
     assert len(res_data['results']) == len(results)
-    assert res_data['results'] == list(reversed(results))
+    assert drop_hrefs(res_data['results']) == drop_hrefs(list(reversed(results)))
     assert len(res_data['waivers']) == len(expected_waivers)
     assert res_data['waivers'] == expected_waivers
 
@@ -1481,7 +1494,7 @@ def test_api_with_when(requests_session, greenwave_server, testdatabuilder):
     res_data = r.json()
 
     assert len(res_data['results']) == 1
-    assert res_data['results'] == [results[0]]
+    assert drop_hrefs(res_data['results']) == drop_hrefs([results[0]])
 
     del data['when']
     r = requests_session.post(greenwave_server + 'api/v1.0/decision', json=data)
@@ -1606,7 +1619,7 @@ def test_make_a_decision_with_verbose_flag_on_demand_policy(
     res_data = r.json()
 
     assert len(res_data['results']) == len(results)
-    assert res_data['results'] == list(reversed(results))
+    assert drop_hrefs(res_data['results']) == drop_hrefs(list(reversed(results)))
     assert len(res_data['waivers']) == len(expected_waivers)
     assert res_data['waivers'] == expected_waivers
     assert len(res_data['satisfied_requirements']) == len(results)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,8 +2,8 @@
 name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -21,8 +21,8 @@ python-dateutil = ">=2.7.0"
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -58,8 +58,8 @@ visualize = ["graphviz (>0.5.1)", "Twisted (>=16.1.1)"]
 name = "babel"
 version = "2.10.1"
 description = "Internationalization utilities"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -69,8 +69,8 @@ pytz = ">=2015.7"
 name = "blinker"
 version = "1.4"
 description = "Fast, simple object-to-object and broadcast signaling"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -134,8 +134,8 @@ python-versions = "*"
 name = "coverage"
 version = "6.3.2"
 description = "Code coverage measurement for Python"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -148,8 +148,8 @@ toml = ["tomli"]
 name = "crochet"
 version = "2.0.0"
 description = "Use Twisted anywhere!"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6.0"
 
 [package.dependencies]
@@ -187,8 +187,8 @@ python-versions = ">=3.5"
 name = "docutils"
 version = "0.17.1"
 description = "Docutils -- Python Documentation Utilities"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
@@ -232,8 +232,8 @@ crypto_ng = ["cryptography (>=1.6)", "pyOpenSSL (>=16.1.0)"]
 name = "fedora-messaging"
 version = "2.1.0"
 description = "A set of tools for using Fedora's messaging infrastructure"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -253,8 +253,8 @@ Twisted = "*"
 name = "flake8"
 version = "3.9.2"
 description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
@@ -293,8 +293,8 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "greenlet"
 version = "1.1.2"
 description = "Lightweight in-process concurrent programming"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
@@ -337,8 +337,8 @@ python-versions = ">=3.5"
 name = "imagesize"
 version = "1.3.0"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -372,8 +372,8 @@ scripts = ["click (>=6.0)", "twisted (>=16.4.0)"]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -402,8 +402,8 @@ i18n = ["Babel (>=2.7)"]
 name = "jsonschema"
 version = "4.4.0"
 description = "An implementation of JSON Schema validation for Python"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -434,16 +434,16 @@ python-versions = ">=3.7"
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [[package]]
 name = "mock"
 version = "4.0.3"
 description = "Rolling backport of unittest.mock for all Pythons"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.extras]
@@ -484,8 +484,8 @@ txZMQ = "*"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -503,8 +503,8 @@ python-versions = ">=2.6"
 name = "pika"
 version = "1.2.0"
 description = "Pika Python AMQP Client Library"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [package.extras]
@@ -516,8 +516,8 @@ twisted = ["twisted"]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.extras]
@@ -547,6 +547,14 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 
 [[package]]
+name = "psycopg2-binary"
+version = "2.9.3"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[[package]]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -558,16 +566,16 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pyasn1"
 version = "0.4.8"
 description = "ASN.1 types and codecs"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [[package]]
 name = "pyasn1-modules"
 version = "0.2.8"
 description = "A collection of ASN.1-based protocols modules."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -577,8 +585,8 @@ pyasn1 = ">=0.4.6,<0.5.0"
 name = "pycodestyle"
 version = "2.7.0"
 description = "Python style guide checker"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -593,8 +601,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pyflakes"
 version = "2.3.1"
 description = "passive checker of Python programs"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -624,8 +632,8 @@ test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 name = "pyparsing"
 version = "3.0.8"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6.8"
 
 [package.extras]
@@ -635,16 +643,16 @@ diagrams = ["railroad-diagrams", "jinja2"]
 name = "pyrsistent"
 version = "0.18.1"
 description = "Persistent/Functional/Immutable data structures"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7"
 
 [[package]]
 name = "pytest"
 version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -664,8 +672,8 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 name = "pytest-cov"
 version = "3.0.0"
 description = "Pytest plugin for measuring coverage."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -747,8 +755,8 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 name = "service-identity"
 version = "21.1.0"
 description = "Service identity verification for pyOpenSSL & cryptography."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -776,16 +784,16 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [[package]]
 name = "sphinx"
 version = "4.5.0"
 description = "Python documentation generator"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -816,8 +824,8 @@ test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -828,8 +836,8 @@ test = ["pytest"]
 name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -840,8 +848,8 @@ test = ["pytest"]
 name = "sphinxcontrib-htmlhelp"
 version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.extras]
@@ -852,8 +860,8 @@ test = ["pytest", "html5lib"]
 name = "sphinxcontrib-httpdomain"
 version = "1.8.0"
 description = "Sphinx domain for documenting HTTP APIs"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.dependencies]
@@ -864,8 +872,8 @@ Sphinx = ">=1.6"
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -875,8 +883,8 @@ test = ["pytest", "flake8", "mypy"]
 name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -887,8 +895,8 @@ test = ["pytest"]
 name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -899,8 +907,8 @@ test = ["pytest"]
 name = "sqlalchemy"
 version = "1.4.35"
 description = "Database Abstraction Library"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
 [package.dependencies]
@@ -953,16 +961,16 @@ future = "*"
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7"
 
 [[package]]
@@ -1063,8 +1071,8 @@ watchdog = ["watchdog"]
 name = "wrapt"
 version = "1.14.0"
 description = "Module for decorators, wrappers and monkey patching."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
@@ -1092,10 +1100,14 @@ docs = ["sphinx", "repoze.sphinx.autointerface"]
 test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
+[extras]
+docs = ["sphinx", "sphinxcontrib-httpdomain"]
+test = ["flake8", "pytest", "pytest-cov", "SQLAlchemy", "mock", "fedora-messaging"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "6717cf880e0032df63f87d268b269bf9b5a44a072a890af21b6bb72ed8122c60"
+content-hash = "6b3717fc2cd6da27bd1f600ff3c2f2233c5eac57a68a5c0e90e90745bda2c5c3"
 
 [metadata.files]
 alabaster = [
@@ -1505,6 +1517,64 @@ psutil = [
     {file = "psutil-5.9.0-cp39-cp39-win32.whl", hash = "sha256:4e2fb92e3aeae3ec3b7b66c528981fd327fb93fd906a77215200404444ec1845"},
     {file = "psutil-5.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3"},
     {file = "psutil-5.9.0.tar.gz", hash = "sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25"},
+]
+psycopg2-binary = [
+    {file = "psycopg2-binary-2.9.3.tar.gz", hash = "sha256:761df5313dc15da1502b21453642d7599d26be88bff659382f8f9747c7ebea4e"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:539b28661b71da7c0e428692438efbcd048ca21ea81af618d845e06ebfd29478"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e82d38390a03da28c7985b394ec3f56873174e2c88130e6966cb1c946508e65"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57804fc02ca3ce0dbfbef35c4b3a4a774da66d66ea20f4bda601294ad2ea6092"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:083a55275f09a62b8ca4902dd11f4b33075b743cf0d360419e2051a8a5d5ff76"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_24_ppc64le.whl", hash = "sha256:0a29729145aaaf1ad8bafe663131890e2111f13416b60e460dae0a96af5905c9"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3a79d622f5206d695d7824cbf609a4f5b88ea6d6dab5f7c147fc6d333a8787e4"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:090f3348c0ab2cceb6dfbe6bf721ef61262ddf518cd6cc6ecc7d334996d64efa"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:a9e1f75f96ea388fbcef36c70640c4efbe4650658f3d6a2967b4cc70e907352e"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c3ae8e75eb7160851e59adc77b3a19a976e50622e44fd4fd47b8b18208189d42"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-win32.whl", hash = "sha256:7b1e9b80afca7b7a386ef087db614faebbf8839b7f4db5eb107d0f1a53225029"},
+    {file = "psycopg2_binary-2.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:8b344adbb9a862de0c635f4f0425b7958bf5a4b927c8594e6e8d261775796d53"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:e847774f8ffd5b398a75bc1c18fbb56564cda3d629fe68fd81971fece2d3c67e"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68641a34023d306be959101b345732360fc2ea4938982309b786f7be1b43a4a1"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3303f8807f342641851578ee7ed1f3efc9802d00a6f83c101d21c608cb864460"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-manylinux_2_24_aarch64.whl", hash = "sha256:e3699852e22aa68c10de06524a3721ade969abf382da95884e6a10ff798f9281"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-manylinux_2_24_ppc64le.whl", hash = "sha256:526ea0378246d9b080148f2d6681229f4b5964543c170dd10bf4faaab6e0d27f"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:b1c8068513f5b158cf7e29c43a77eb34b407db29aca749d3eb9293ee0d3103ca"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:15803fa813ea05bef089fa78835118b5434204f3a17cb9f1e5dbfd0b9deea5af"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:152f09f57417b831418304c7f30d727dc83a12761627bb826951692cc6491e57"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:404224e5fef3b193f892abdbf8961ce20e0b6642886cfe1fe1923f41aaa75c9d"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-win32.whl", hash = "sha256:1f6b813106a3abdf7b03640d36e24669234120c72e91d5cbaeb87c5f7c36c65b"},
+    {file = "psycopg2_binary-2.9.3-cp36-cp36m-win_amd64.whl", hash = "sha256:2d872e3c9d5d075a2e104540965a1cf898b52274a5923936e5bfddb58c59c7c2"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:10bb90fb4d523a2aa67773d4ff2b833ec00857f5912bafcfd5f5414e45280fb1"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:874a52ecab70af13e899f7847b3e074eeb16ebac5615665db33bce8a1009cf33"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a29b3ca4ec9defec6d42bf5feb36bb5817ba3c0230dd83b4edf4bf02684cd0ae"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:12b11322ea00ad8db8c46f18b7dfc47ae215e4df55b46c67a94b4effbaec7094"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-manylinux_2_24_ppc64le.whl", hash = "sha256:53293533fcbb94c202b7c800a12c873cfe24599656b341f56e71dd2b557be063"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c381bda330ddf2fccbafab789d83ebc6c53db126e4383e73794c74eedce855ef"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9d29409b625a143649d03d0fd7b57e4b92e0ecad9726ba682244b73be91d2fdb"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:183a517a3a63503f70f808b58bfbf962f23d73b6dccddae5aa56152ef2bcb232"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:15c4e4cfa45f5a60599d9cec5f46cd7b1b29d86a6390ec23e8eebaae84e64554"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-win32.whl", hash = "sha256:adf20d9a67e0b6393eac162eb81fb10bc9130a80540f4df7e7355c2dd4af9fba"},
+    {file = "psycopg2_binary-2.9.3-cp37-cp37m-win_amd64.whl", hash = "sha256:2f9ffd643bc7349eeb664eba8864d9e01f057880f510e4681ba40a6532f93c71"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:def68d7c21984b0f8218e8a15d514f714d96904265164f75f8d3a70f9c295667"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dffc08ca91c9ac09008870c9eb77b00a46b3378719584059c034b8945e26b272"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:280b0bb5cbfe8039205c7981cceb006156a675362a00fe29b16fbc264e242834"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:af9813db73395fb1fc211bac696faea4ca9ef53f32dc0cfa27e4e7cf766dcf24"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_24_ppc64le.whl", hash = "sha256:63638d875be8c2784cfc952c9ac34e2b50e43f9f0a0660b65e2a87d656b3116c"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ffb7a888a047696e7f8240d649b43fb3644f14f0ee229077e7f6b9f9081635bd"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0c9d5450c566c80c396b7402895c4369a410cab5a82707b11aee1e624da7d004"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:d1c1b569ecafe3a69380a94e6ae09a4789bbb23666f3d3a08d06bbd2451f5ef1"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8fc53f9af09426a61db9ba357865c77f26076d48669f2e1bb24d85a22fb52307"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-win32.whl", hash = "sha256:6472a178e291b59e7f16ab49ec8b4f3bdada0a879c68d3817ff0963e722a82ce"},
+    {file = "psycopg2_binary-2.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:35168209c9d51b145e459e05c31a9eaeffa9a6b0fd61689b48e07464ffd1a83e"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:47133f3f872faf28c1e87d4357220e809dfd3fa7c64295a4a148bcd1e6e34ec9"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91920527dea30175cc02a1099f331aa8c1ba39bf8b7762b7b56cbf54bc5cce42"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887dd9aac71765ac0d0bac1d0d4b4f2c99d5f5c1382d8b770404f0f3d0ce8a39"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:1f14c8b0942714eb3c74e1e71700cbbcb415acbc311c730370e70c578a44a25c"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_24_ppc64le.whl", hash = "sha256:7af0dd86ddb2f8af5da57a976d27cd2cd15510518d582b478fbb2292428710b4"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:93cd1967a18aa0edd4b95b1dfd554cf15af657cb606280996d393dadc88c3c35"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bda845b664bb6c91446ca9609fc69f7db6c334ec5e4adc87571c34e4f47b7ddb"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:01310cf4cf26db9aea5158c217caa92d291f0500051a6469ac52166e1a16f5b7"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:99485cab9ba0fa9b84f1f9e1fef106f44a46ef6afdeec8885e0b88d0772b49e8"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-win32.whl", hash = "sha256:46f0e0a6b5fa5851bbd9ab1bc805eef362d3a230fbdfbc209f4a236d0a7a990d"},
+    {file = "psycopg2_binary-2.9.3-cp39-cp39-win_amd64.whl", hash = "sha256:accfe7e982411da3178ec690baaceaad3c278652998b2c45828aaac66cd8285f"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,18 +35,34 @@ fedmsg = {extras = ["consumers"], version = "^1.1.2"}
 python-dateutil = "^2.8.2"
 stomper = "^0.4.3"
 
-[tool.poetry.dev-dependencies]
-# Testing requirements
-flake8 = "^3.9.2"
-pytest = "^6.2.5"
-pytest-cov = "^3.0.0"
-SQLAlchemy = "^1.4.25"
-mock = "^4.0.3"
-fedora-messaging = "^2.1.0"
+flake8 = {version = "^3.9.2", optional = true}
+pytest = {version = "^6.2.5", optional = true}
+pytest-cov = {version = "^3.0.0", optional = true}
+mock = {version = "^4.0.3", optional = true}
 
-# Documentation build requirements
-sphinx = "^4.0.2"
-sphinxcontrib-httpdomain = "^1.8.0"
+SQLAlchemy = {version = "^1.4.25", optional = true}
+fedora-messaging = {version = "^2.1.0", optional = true}
+psycopg2-binary = {version = "^2.9.3", optional = true}
+
+sphinx = {version = "^4.0.2", optional = true}
+sphinxcontrib-httpdomain = {version = "^1.8.0", optional = true}
+
+[tool.poetry.extras]
+test = [
+    "flake8",
+    "pytest",
+    "pytest-cov",
+    "mock",
+    "fedora-messaging",
+]
+functional-test = [
+    "SQLAlchemy",
+    "psycopg2-binary",
+]
+docs = [
+    "sphinx",
+    "sphinxcontrib-httpdomain",
+]
 
 [tool.poetry.plugins."moksha.consumer"]
 resultsdb = "greenwave.consumers.resultsdb:ResultsDBHandler"

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,43 @@
 [tox]
 envlist = bandit,lint,py39,docs
 isolated_build = True
-# If the user is missing an interpreter, don't fail
-skip_missing_interpreters = True
+
+[tox:.package]
+basepython = python3
 
 [testenv]
-basepython = python3.9
-whitelist_externals =
-    poetry
-    rm
+extras =
+    test
 setenv =
     GREENWAVE_CONFIG={toxinidir}/conf/settings.py.example
 commands =
-    poetry install -v --no-root
-    rm -rf htmlcov coverage.xml
-    poetry run pytest greenwave/tests/ \
-        --cov-config .coveragerc --cov=greenwave --cov-report term \
-        --cov-report xml --cov-report html {posargs}
+    pytest \
+        --cov-reset \
+        --cov-config=.coveragerc \
+        --cov=greenwave \
+        --cov-report=term \
+        --cov-report=xml \
+        --cov-report=html \
+        --ignore=functional-tests \
+        {posargs}
+
+[testenv:functional]
+extras =
+    test
+    functional-test
+setenv =
+    GREENWAVE_TEST_URL=http://localhost:8080/
+    WAIVERDB_TEST_URL=http://localhost:5004/
+    RESULTSDB_TEST_URL=http://localhost:5001/
+commands =
+    pytest \
+        --cov-reset \
+        --cov-config=.coveragerc \
+        --cov=greenwave \
+        --cov-report=term \
+        --cov-report=xml \
+        --cov-report=html \
+        {posargs}
 
 [testenv:bandit]
 skip_install = true
@@ -29,15 +50,15 @@ commands =
 
 [testenv:docs]
 changedir = docs
+extras =
+    docs
 whitelist_externals =
     mkdir
-    poetry
     rm
 commands=
-    poetry install -v --no-root
     mkdir -p _static
     rm -rf _build/
-    poetry run sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
+    sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Uses package extras to install dependencies for tests and documentation
build run by tox.

Run functional tests outside of containers created by docker-compose.
This avoids somewhat broken installation of tests dependencies in the
containers and simplifies creating coverage.