### PR TITLE
CI: Avoid logging into registry for dependabot PRs

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -123,7 +123,7 @@ jobs:
           containerfiles: Dockerfile
 
       - name: Log in to the image registry
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
         uses: redhat-actions/podman-login@v1
         with:
           registry: ${{ secrets.REGISTRY_USER && env.REGISTRY || env.GH_REGISTRY }}


### PR DESCRIPTION
Fixes the following error:

    ##[group]Run redhat-actions/podman-login@v1
    with:
      registry: ghcr.io/dependabot[bot]
      username: dependabot[bot]
      password: ***
      logout: true
    env:
      IMAGE_NAME: greenwave
      REGISTRY: quay.io/factory2
      GH_REGISTRY: ghcr.io/dependabot[bot]
    ##[endgroup]
    ##[group]/usr/bin/podman version
    [command]/usr/bin/podman version
    Version:      3.4.2
    API Version:  3.4.2
    Go Version:   go1.16.6
    Built:        Thu Jan  1 00:00:00 1970
    OS/Arch:      linux/amd64
    ##[endgroup]
    [command]/usr/bin/podman login ghcr.io/dependabot[bot] -u dependabot[bot] -p ***
    Error: parse reference from "ghcr.io/dependabot[bot]": invalid reference format
    ##[error]Error: podman exited with code 125
    Error: parse reference from "ghcr.io/dependabot[bot]": invalid reference format