### PR TITLE
Add missing moksha dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -161,7 +161,7 @@ name = "cryptography"
 version = "36.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -626,7 +626,7 @@ name = "pyopenssl"
 version = "22.0.0"
 description = "Python wrapper module around the OpenSSL library"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -1130,7 +1130,7 @@ test = ["flake8", "pytest", "pytest-cov", "mock", "fedora-messaging"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "67827491dfde6b1872aab02e233b5648398f9442ade97743e6ff4689065e2737"
+content-hash = "b73a666495feb246f981b7159f2f7d92a317f680f514b27dd4c440ebd44c6f0a"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,13 @@ gunicorn = "^20.1.0"
 python-memcached = "^1.59"
 prometheus-client = "^0.14.1"
 requests = "^2.26.0"
-fedmsg = {extras = ["consumers"], version = "^1.1.2"}
 python-dateutil = "^2.8.2"
-stomper = "^0.4.3"
 "stomp.py" = "^8.0.0"
 cryptography = {version = "^36.0.2", optional = true}
+
+fedmsg = {extras = ["consumers"], version = "^1.1.2"}
+stomper = "^0.4.3"
+pyOpenSSL = "^22.0.0"
 
 flake8 = {version = "^4.0.1", optional = true}
 pytest = {version = "^7.1.2", optional = true}


### PR DESCRIPTION
Fixes the following error:

    Traceback (most recent call last):
      File "/venv/bin/fedmsg-hub", line 8, in <module>
        sys.exit(hub())
      File "/venv/lib64/python3.9/site-packages/fedmsg/commands/hub.py", line 122, in hub
        command.execute()
      File "/venv/lib64/python3.9/site-packages/fedmsg/commands/__init__.py", line 67, in execute
        return self.run()
      File "/venv/lib64/python3.9/site-packages/fedmsg/commands/hub.py", line 94, in run
        main(
      File "/venv/lib64/python3.9/site-packages/moksha/hub/__init__.py", line 81, in main
        hub = CentralMokshaHub(config, consumers=consumers, producers=producers)
      File "/venv/lib64/python3.9/site-packages/moksha/hub/hub.py", line 270, in __init__
        super(CentralMokshaHub, self).__init__(config)
      File "/venv/lib64/python3.9/site-packages/moksha/hub/hub.py", line 125, in __init__
        self.extensions = [
      File "/venv/lib64/python3.9/site-packages/moksha/hub/hub.py", line 126, in <listcomp>
        ext(self, config) for ext in find_hub_extensions(config)
      File "/venv/lib64/python3.9/site-packages/moksha/hub/stomp/stomp.py", line 74, in __init__
        self.connect(self.addresses[self.address_index], self.key, self.crt)
      File "/venv/lib64/python3.9/site-packages/moksha/hub/stomp/stomp.py", line 83, in connect
        from twisted.internet import ssl
      File "/venv/lib64/python3.9/site-packages/twisted/internet/ssl.py", line 60, in <module>
        from OpenSSL import SSL
    ModuleNotFoundError: No module named 'OpenSSL'