### PR TITLE
Fix timeout when connecting to UMB broker pair

### DIFF
--- a/greenwave/config.py
+++ b/greenwave/config.py
@@ -77,10 +77,10 @@ class Config(object):
     LISTENER_CONNECTION = {
         "heartbeats": (10000, 20000),
         "keepalive": True,
-        "timeout": 5000,
+        "timeout": 10,
         "reconnect_sleep_initial": 1.0,
         "reconnect_sleep_increase": 1.0,
-        "reconnect_sleep_max": 60.0,
+        "reconnect_sleep_max": 30.0,
         "reconnect_attempts_max": 10,
     }
     LISTENER_CONNECTION_SSL = {


### PR DESCRIPTION
By default the timeout is ~1 minute which causes unnecessary delay when
connecting to broker pair and the first broker is inactive.