### PR TITLE
Fix Hadolint warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.5 as builder
 
-# hadolint ignore=DL3033,DL4006,SC3040
+# hadolint ignore=DL3033,DL4006,SC2039,SC3040
 RUN set -exo pipefail \
     && mkdir -p /mnt/rootfs \
     # install builder dependencies


### PR DESCRIPTION
Fixes the following warning:

    SC2039 warning: In POSIX sh, set option pipefail is undefined.