### PR TITLE
Use only viable metrics

### DIFF
--- a/greenwave/consumers/resultsdb.py
+++ b/greenwave/consumers/resultsdb.py
@@ -54,7 +54,7 @@ class ResultsDBHandler(Consumer):
     config_key = 'resultsdb_handler'
     hub_config_prefix = 'resultsdb_'
     default_topic = 'taskotron.result.new'
-    monitor_labels = {'handler': 'resultsdb'}
+    monitor_labels = {'handler': 'resultsdb_consumer'}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/greenwave/consumers/waiverdb.py
+++ b/greenwave/consumers/waiverdb.py
@@ -24,7 +24,7 @@ class WaiverDBHandler(Consumer):
     config_key = 'waiverdb_handler'
     hub_config_prefix = 'waiverdb_'
     default_topic = 'waiver.new'
-    monitor_labels = {'handler': 'waiverdb'}
+    monitor_labels = {'handler': 'waiverdb_consumer'}
 
     def _consume_message(self, message):
         msg = message['msg']

--- a/greenwave/monitor.py
+++ b/greenwave/monitor.py
@@ -84,10 +84,6 @@ messaging_rx_processed_ok_counter = Counter('messaging_rx_processed_ok')
 # Number of received messages, which failed during processing
 messaging_rx_failed_counter = Counter('messaging_rx_failed')
 
-# Total number of messages to send
-messaging_tx_to_send_counter = Counter('messaging_tx_to_send')
-# Number of messages, which were eventually stopped before sending
-messaging_tx_stopped_counter = Counter('messaging_tx_stopped')
 # Number of messages, which were sent successfully
 messaging_tx_sent_ok_counter = Counter('messaging_tx_sent_ok')
 # Number of messages, for which the sender failed
@@ -97,7 +93,9 @@ messaging_tx_failed_counter = Counter('messaging_tx_failed')
 decision_exception_counter = Counter('total_decision_exceptions')
 # Decision latency
 decision_request_duration_seconds = Histogram('decision_request_duration_seconds')
-# All exceptions occurred in publishing a message after a new waiver
-publish_decision_exceptions_waiver_counter = Counter('publish_decision_exceptions_new_waiver')
-# All exceptions occurred in publishing a message after a new result
-publish_decision_exceptions_result_counter = Counter('publish_decision_exceptions_new_result')
+# New result/waiver caused specific decision to change
+decision_changed_counter = Counter('decision_changed')
+# New result/waiver did not cause specific decision to change
+decision_unchanged_counter = Counter('decision_unchanged')
+# Failed to retrieve decision for a new result/waiver
+decision_failed_counter = Counter('decision_failed')


### PR DESCRIPTION
This adds decision_changed/unchanged/failed counters to keep track of
each decision_context value from policies that is used when new results
and waivers are received.

Messaging metrics collected by old consumers contain the "handler" label
with suffix "_consumer".