### PR TITLE
Remove fedora-messaging related codes in greenwave/consumers

### DIFF
--- a/functional-tests/consumers/test_waiverdb.py
+++ b/functional-tests/consumers/test_waiverdb.py
@@ -23,9 +23,9 @@ def create_waiverdb_handler(greenwave_server):
 
 
 @pytest.mark.parametrize('subject_type', ('koji_build', 'brew-build'))
-@mock.patch('greenwave.consumers.consumer.fedmsg.publish')
+@mock.patch('greenwave.consumers.consumer.fedora_messaging.api.publish')
 def test_consume_new_waiver(
-        mock_fedmsg, requests_session, greenwave_server, testdatabuilder,
+        mock_fedora_messaging, requests_session, greenwave_server, testdatabuilder,
         subject_type):
     nvr = testdatabuilder.unique_nvr()
 
@@ -62,9 +62,12 @@ def test_consume_new_waiver(
     handler = create_waiverdb_handler(greenwave_server)
     handler.consume(message)
 
-    assert len(mock_fedmsg.mock_calls) == 1
-    assert all(call[2]['topic'] == 'decision.update' for call in mock_fedmsg.mock_calls)
-    actual_msgs_sent = [call[2]['msg'] for call in mock_fedmsg.mock_calls]
+    assert len(mock_fedora_messaging.mock_calls) == 1
+    assert all(
+        call[1][0].topic == "greenwave.decision.update"
+        for call in mock_fedora_messaging.mock_calls
+    )
+    actual_msgs_sent = [call[1][0].body for call in mock_fedora_messaging.mock_calls]
     assert actual_msgs_sent[0] == {
         'applicable_policies': ['taskotron_release_critical_tasks_with_blacklist',
                                 'taskotron_release_critical_tasks'],

--- a/greenwave/config.py
+++ b/greenwave/config.py
@@ -45,8 +45,6 @@ class Config(object):
     POLICIES_DIR = '/etc/greenwave/policies'
     SUBJECT_TYPES_DIR = '/etc/greenwave/subject_types'
 
-    MESSAGING = 'fedmsg'
-
     # By default, don't cache anything.
     CACHE = {'backend': 'dogpile.cache.null'}
     # Greenwave API url

--- a/greenwave/consumers/__init__.py
+++ b/greenwave/consumers/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: GPL-2.0+
-"""Contains Greenwave's fedmsg consumers."""
+"""Contains Greenwave's fedora-messaging consumers."""

--- a/greenwave/consumers/fedora_messaging_consumer.py
+++ b/greenwave/consumers/fedora_messaging_consumer.py
@@ -5,8 +5,8 @@ The fedora-messaging consumer.
 
 This module is responsible consuming messages sent to the fedora message bus via
 fedora-messaging.
-It will get all the messages and pass them onto their appropriate fedmsg
-consumers to re-use the same code path.
+It will get all the messages and pass them onto their appropriate base consumers
+to re-use the same code path.
 """
 
 import logging
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 class Dummy(object):
     """ Dummy object only storing a dictionary named "config" that can be passed
-    onto the fedmsg consumer.
+    onto the base consumer.
     """
 
     def __init__(self, config):
@@ -35,8 +35,8 @@ class Dummy(object):
 def fedora_messaging_callback(message):
     """
     Callback called when messages from fedora-messaging are received.
-    It then passes them onto their appropriate fedmsg handler for code
-    portability.
+    It then passes them onto their appropriate resultdb and waiverdb
+    handler for code portability.
 
     Args:
         message (fedora_messaging.message.Message): The message we received

--- a/greenwave/consumers/resultsdb.py
+++ b/greenwave/consumers/resultsdb.py
@@ -48,7 +48,8 @@ class ResultsDBHandler(Consumer):
     Handle a new result.
 
     Attributes:
-        topic (list): A list of strings that indicate which fedmsg topics this consumer listens to.
+        topic (list): A list of strings that indicate which fedora-messaging topics
+        this consumer listens to.
     """
 
     config_key = 'resultsdb_handler'
@@ -67,7 +68,7 @@ class ResultsDBHandler(Consumer):
         consideration from the message.
 
         Args:
-            message (munch.Munch): A fedmsg about a new result.
+            message (fedora_messaging.message.Message): A fedora messaging about a new result.
         """
 
         try:

--- a/greenwave/consumers/waiverdb.py
+++ b/greenwave/consumers/waiverdb.py
@@ -18,7 +18,8 @@ class WaiverDBHandler(Consumer):
     Handle a new waiver.
 
     Attributes:
-        topic (list): A list of strings that indicate which fedmsg topics this consumer listens to.
+        topic (list): A list of strings that indicate which fedora message topics
+        this consumer listens to.
     """
 
     config_key = 'waiverdb_handler'

--- a/greenwave/listeners/base.py
+++ b/greenwave/listeners/base.py
@@ -272,7 +272,7 @@ class BaseListener(stomp.ConnectionListener):
 
             if _is_decision_unchanged(old_decision, decision):
                 self.app.logger.debug(
-                    "Skipped emitting fedmsg, decision did not change: %s", decision
+                    "Skipped emitting fedora message, decision did not change: %s", decision
                 )
                 self._inc(decision_unchanged_counter.labels(decision_context=decision_context))
                 continue

--- a/greenwave/tests/test_listeners.py
+++ b/greenwave/tests/test_listeners.py
@@ -211,7 +211,7 @@ def test_announcement_subjects_for_new_compose_message():
     as this has caused a lot of confusion in the past. The only
     reliable way to make a compose decision is by looking for the key
     productmd.compose.id with value of the compose ID. This is only
-    possible with new-style 'resultsdb' fedmsgs, like this one.
+    possible with new-style 'resultsdb' message, like this one.
     """
     message = {
         "data": {
@@ -238,7 +238,7 @@ def test_announcement_subjects_for_new_compose_message():
 
 
 def test_no_announcement_subjects_for_old_compose_message():
-    """With an old-style 'taskotron' fedmsg like this one, it is not
+    """With an old-style 'taskotron' message like this one, it is not
     possible to reliably make a compose decision - see
     https://pagure.io/greenwave/issue/122 etc. So we should NOT
     produce any subjects for this kind of message.
@@ -494,7 +494,7 @@ def test_remote_rule_decision_change(
             "policies_satisfied": True,
             "previous": {"policies_satisfied": False},
         },
-        # Duplication of the topic in the body for datanommer, for fedmsg backwards compat
+        # Duplication of the topic in the body for datanommer, for message backwards compat
         "topic": DECISION_UPDATE_TOPIC,
     }
 
@@ -694,7 +694,7 @@ def test_decision_change_for_modules(
             "policies_satisfied": True,
             "previous": {"policies_satisfied": False},
         },
-        # Duplication of the topic in the body for datanommer, for fedmsg backwards compat
+        # Duplication of the topic in the body for datanommer, for message backwards compat
         "topic": DECISION_UPDATE_TOPIC,
     }
 
@@ -759,7 +759,7 @@ def test_decision_change_for_composes(
             "policies_satisfied": True,
             "previous": {"policies_satisfied": False},
         },
-        # Duplication of the topic in the body for datanommer, for fedmsg backwards compat
+        # Duplication of the topic in the body for datanommer, for message backwards compat
         "topic": DECISION_UPDATE_TOPIC,
     }
 
@@ -851,7 +851,7 @@ def test_fake_fedora_messaging_msg(mock_retrieve_results, mock_connection):
             "policies_satisfied": True,
             "previous": {"policies_satisfied": False},
         },
-        # Duplication of the topic in the body for datanommer, for fedmsg backwards compat
+        # Duplication of the topic in the body for datanommer, for message backwards compat
         "topic": DECISION_UPDATE_TOPIC,
     }
 
@@ -920,7 +920,7 @@ def test_container_brew_build(mock_retrieve_results, koji_proxy, mock_connection
             "policies_satisfied": True,
             "previous": {"policies_satisfied": False},
         },
-        # Duplication of the topic in the body for datanommer, for fedmsg backwards compat
+        # Duplication of the topic in the body for datanommer, for message backwards compat
         "topic": DECISION_UPDATE_TOPIC,
     }
 
@@ -969,7 +969,7 @@ def test_waiverdb_message(mock_connection):
             "policies_satisfied": True,
             "previous": {"policies_satisfied": False},
         },
-        # Duplication of the topic in the body for datanommer, for fedmsg backwards compat
+        # Duplication of the topic in the body for datanommer, for message backwards compat
         "topic": DECISION_UPDATE_TOPIC,
     }
 


### PR DESCRIPTION
As bodhi use ResultsDB and WaiverDB consumers instead of Greenwave
consumer, removing fedora-messaging related codes in
greenwave/consumers.

JIRA: RHELWF-4782