### PR TITLE
Use more up-to-date memcached package

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,8 @@ services:
 
   memcached:
     image: "quay.io/factory2/memcached"
+    ports:
+      - 11211:11211
 
   resultsdb-listener:
     image: greenwave

--- a/docker/greenwave-settings.py
+++ b/docker/greenwave-settings.py
@@ -17,8 +17,8 @@ LISTENER_CONNECTION = {
     "reconnect_attempts_max": 5,
 }
 CACHE = {
-    # 'backend': "dogpile.cache.null",
-    'backend': "dogpile.cache.memcached",
+    # 'backend': 'dogpile.cache.null',
+    'backend': 'dogpile.cache.pymemcache',
     'expiration_time': 1,  # 1 is 1 second, keep to see that memcached
                            # service is working
     'arguments': {

--- a/functional-tests/conftest.py
+++ b/functional-tests/conftest.py
@@ -196,7 +196,7 @@ def cache_config(tmpdir_factory):
     if 'GREENWAVE_TEST_URL' in os.environ:
         # This should point to the same cache as the Greenwave server used by tests.
         return {
-            'backend': "dogpile.cache.memcached",
+            'backend': 'dogpile.cache.pymemcache',
             'expiration_time': 300,
             'arguments': {
                 'url': 'memcached:11211',

--- a/functional-tests/test_cache.py
+++ b/functional-tests/test_cache.py
@@ -1,0 +1,21 @@
+import uuid
+
+from dogpile.cache import make_region
+
+from greenwave.utils import sha1_mangle_key
+
+
+def test_cache():
+    cache = make_region(key_mangler=sha1_mangle_key)
+    cache.configure(
+        backend='dogpile.cache.pymemcache',
+        expiration_time=5,
+        arguments={
+            'url': 'localhost:11211',
+            'distributed_lock': True,
+        },
+    )
+    key = uuid.uuid1().hex
+    assert cache.get(key) is not True
+    cache.set(key, True)
+    assert cache.get(key) is True

--- a/openshift/greenwave-test-template.yaml
+++ b/openshift/greenwave-test-template.yaml
@@ -103,8 +103,8 @@ objects:
       WAIVERDB_API_URL = 'http://waiverdb-test-${TEST_ID}-web:8080/api/v1.0'
       RESULTSDB_API_URL = 'http://resultsdb-test-${TEST_ID}-internal-api:5001/api/v2.0'
       CACHE = {
-          #'backend': "dogpile.cache.null",
-          'backend': "dogpile.cache.memcached",
+          #'backend': 'dogpile.cache.null',
+          'backend': 'dogpile.cache.pymemcache',
           'expiration_time': 1, # 1 is 1 second, keep to see that memcached
                                 # service is working
           'arguments': {

--- a/poetry.lock
+++ b/poetry.lock
@@ -535,6 +535,17 @@ optional = true
 python-versions = ">=3.6"
 
 [[package]]
+name = "pymemcache"
+version = "3.5.2"
+description = "A comprehensive, fast, pure Python memcached client"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "pyopenssl"
 version = "22.0.0"
 description = "Python wrapper module around the OpenSSL library"
@@ -614,17 +625,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
 six = ">=1.5"
-
-[[package]]
-name = "python-memcached"
-version = "1.59"
-description = "Pure python memcached client"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = ">=1.4.0"
 
 [[package]]
 name = "pytz"
@@ -1005,7 +1005,7 @@ test = ["flake8", "pytest", "pytest-cov", "mock"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "34b4648ff601b8b855d6ca85c5c3538a99d5e4865751f995acef73d194ee84f0"
+content-hash = "6ae50be7dc85af7cfada7e250456e7f0b1b830eb3664d25d770095b107c10e38"
 
 [metadata.files]
 alabaster = [
@@ -1434,6 +1434,7 @@ pygments = [
     {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
     {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
 ]
+pymemcache = []
 pyopenssl = [
     {file = "pyOpenSSL-22.0.0-py2.py3-none-any.whl", hash = "sha256:ea252b38c87425b64116f808355e8da644ef9b07e429398bfece610f893ee2e0"},
     {file = "pyOpenSSL-22.0.0.tar.gz", hash = "sha256:660b1b1425aac4a1bea1d94168a85d99f0b3144c869dd4390d27629d0087f1bf"},
@@ -1476,10 +1477,6 @@ pytest-cov = [
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
-]
-python-memcached = [
-    {file = "python-memcached-1.59.tar.gz", hash = "sha256:a2e28637be13ee0bf1a8b6843e7490f9456fd3f2a4cb60471733c7b5d5557e4f"},
-    {file = "python_memcached-1.59-py2.py3-none-any.whl", hash = "sha256:4dac64916871bd3550263323fc2ce18e1e439080a2d5670c594cf3118d99b594"},
 ]
 pytz = [
     {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ PyYAML = "^6.0"
 "dogpile.cache" = "^1.1.4"
 flask = "^2.1.2"
 gunicorn = "^20.1.0"
-python-memcached = "^1.59"
 requests = "^2.28.1"
 python-dateutil = "^2.8.2"
 fedora-messaging = "^2.1.0"
@@ -46,6 +45,7 @@ psycopg2-binary = {version = "^2.9.3", optional = true}
 sphinx = {version = "^5.0.2", optional = true}
 sphinxcontrib-httpdomain = {version = "^1.8.0", optional = true}
 statsd = "^3.3.0"
+pymemcache = "^3.5.2"
 
 [tool.poetry.extras]
 test = [


### PR DESCRIPTION
python-memcached has not beed updated in many years and we now see the
following error appear everywhere in the logs
(https://github.com/linsomniac/python-memcached/issues/176):

    /venv/lib64/python3.9/site-packages/memcache.py:1304: SyntaxWarning: "is" with a literal. Did you mean "=="?
      if key_extra_len is 0: