### PR TITLE
Satisfy flake8 5.0.1

### DIFF
--- a/functional-tests/test_api_v1.py
+++ b/functional-tests/test_api_v1.py
@@ -787,7 +787,7 @@ def test_ignore_result(requests_session, greenwave_server, testdatabuilder):
 
     # repeating the test for "when" parameter instead of "ignore_result"
     # ...we should get the same behaviour.
-    del(data['ignore_result'])
+    del data['ignore_result']
     data['when'] = right_before_this_time(result['submit_time'])
     r = requests_session.post(greenwave_server + 'api/v1.0/decision', json=data)
     assert r.status_code == 200
@@ -929,7 +929,7 @@ def test_ignore_waiver(requests_session, greenwave_server, testdatabuilder):
 
     # repeating the test for "when" parameter instead of "ignore_waiver"
     # ...we should get the same behaviour.
-    del(data['ignore_waiver'])
+    del data['ignore_waiver']
     data['when'] = right_before_this_time(waiver['timestamp'])
     r_ = requests_session.post(greenwave_server + 'api/v1.0/decision', json=data)
     assert r_.status_code == 200


### PR DESCRIPTION
This fixes the following errors reported by flake8 5.0.1 (the dependency
can by updated afterwards):

    ./functional-tests/test_api_v1.py:790:8: E275 missing whitespace after keyword
        del(data['ignore_result'])
           ^
    ./functional-tests/test_api_v1.py:932:8: E275 missing whitespace after keyword
        del(data['ignore_waiver'])
           ^