### PR TITLE
Fix waiving all scenarios

### DIFF
--- a/greenwave/decision.py
+++ b/greenwave/decision.py
@@ -97,13 +97,14 @@ class Decision:
         if not self.verbose:
             for answer in self.answers:
                 if not answer.is_satisfied:
-                    self.waiver_filters.append(dict(
-                        subject_type=answer.subject.type,
-                        subject_identifier=answer.subject.identifier,
-                        product_version=self.product_version,
-                        testcase=answer.test_case_name,
-                        scenario=answer.scenario
-                    ))
+                    waiver = {
+                        "subject_type": answer.subject.type,
+                        "subject_identifier": answer.subject.identifier,
+                        "product_version": self.product_version,
+                        "testcase": answer.test_case_name,
+                    }
+                    if waiver not in self.waiver_filters:
+                        self.waiver_filters.append(waiver)
 
         if self.waiver_filters:
             self.waivers = waivers_retriever.retrieve(self.waiver_filters)

--- a/greenwave/tests/test_waive.py
+++ b/greenwave/tests/test_waive.py
@@ -228,3 +228,54 @@ def test_waive_scenario():
     )
     assert 1 == len(waived)
     assert expected_json == waived[0].to_json()
+
+
+def test_waive_scenarios_all():
+    answers = [
+        TestResultFailed(
+            subject=test_subject(),
+            test_case_name='test1',
+            source='https://greenwave_tests.example.com',
+            result_id=98,
+            data={'scenario': 'scenario1'},
+        ),
+        TestResultFailed(
+            subject=test_subject(),
+            test_case_name='test1',
+            source='https://greenwave_tests.example.com',
+            result_id=99,
+            data={'scenario': 'scenario2'},
+        )
+    ]
+
+    waivers = [
+        dict(
+            subject_type='koji_build',
+            subject_identifier='nethack-1.2.3-1.rawhide',
+            product_version='rawhide',
+            testcase='test1',
+            scenario=None
+        )
+    ]
+    waived = waive_answers(answers, waivers)
+    expected_json = [
+        dict(
+            type='test-result-failed-waived',
+            testcase='test1',
+            subject_type='koji_build',
+            subject_identifier='nethack-1.2.3-1.rawhide',
+            result_id=98,
+            scenario='scenario1',
+            source='https://greenwave_tests.example.com',
+        ),
+        dict(
+            type='test-result-failed-waived',
+            testcase='test1',
+            subject_type='koji_build',
+            subject_identifier='nethack-1.2.3-1.rawhide',
+            result_id=99,
+            scenario='scenario2',
+            source='https://greenwave_tests.example.com',
+        ),
+    ]
+    assert expected_json == [w.to_json() for w in waived]


### PR DESCRIPTION
If a matching waiver has scenario=null, it should apply to all test
results disregarding their scenario values.

JIRA: RHELWF-7314