### PR TITLE
add headers to messages produced on decision changes

### DIFF
--- a/greenwave/listeners/base.py
+++ b/greenwave/listeners/base.py
@@ -209,8 +209,16 @@ class BaseListener(stomp.ConnectionListener):
         body = json.dumps(message)
         while True:
             try:
+                headers = {
+                    "subject_type": decision["subject_type"],
+                    "subject_identifier": decision["subject_identifier"],
+                    "product_version": decision["product_version"],
+                    "decision_context": decision["decision_context"],
+                    "policies_satisfied": str(decision["policies_satisfied"]).lower(),
+                    "summary": decision["summary"],
+                }
                 self.connection.send(
-                    body=body, headers={}, destination=self.destination
+                    body=body, headers=headers, destination=self.destination
                 )
                 break
             except stomp.exception.NotConnectedException:


### PR DESCRIPTION
Message headers allow clients to select which messages they are interested in, avoiding the delivery of irrelevant messages, simplifying message handling, and reducing load. The following message properties are exposed as message headers:

- subject_type
- subject_identifier
- product_version
- decision_context
- policies_satisified
- summary