### PR TITLE
Use correct stable git commit reference

### DIFF
--- a/greenwave/resources.py
+++ b/greenwave/resources.py
@@ -188,10 +188,12 @@ def _retrieve_koji_build_attributes(nvr, koji_url):
 
     task_id = build.get("task_id")
 
-    try:
-        source = build["extra"]["source"]["original_url"]
-    except (TypeError, KeyError, AttributeError):
-        source = build.get("source")
+    source = build.get("source")
+    if not source:
+        try:
+            source = build["extra"]["source"]["original_url"]
+        except (TypeError, KeyError, AttributeError):
+            source = None
 
     creation_time = build.get('creation_time')
 

--- a/greenwave/tests/test_retrieve_gating_yaml.py
+++ b/greenwave/tests/test_retrieve_gating_yaml.py
@@ -20,12 +20,11 @@ def test_retrieve_scm_from_rpm_build(app, koji_proxy):
         'nvr': nvr,
         'extra': {
             'source': {
-                'original_url': 'git+https://src.fedoraproject.org/rpms/nethack.git#'
-                                '0c1a84e0e8a152897003bd7e27b3f407ff6ba040'
+                'original_url': 'git+https://src.fedoraproject.org/rpms/nethack.git#master'
             }
         },
-        # also check, that there's no fallback to source
-        'source': 'git+https://src.fedoraproject.org/rpms/nethack.git#master'
+        'source': 'git+https://src.fedoraproject.org/rpms/nethack.git#'
+                  '0c1a84e0e8a152897003bd7e27b3f407ff6ba040'
     }
     namespace, pkg_name, rev = retrieve_scm_from_koji(nvr)
     assert namespace == 'rpms'


### PR DESCRIPTION
According to Koji documentation, "source" contains a git commit SHA and "extra.source.original_url" the reference to a git branch.

Fixes: https://pagure.io/fedora-infrastructure/issue/10896