### PR TITLE
Allow querying multiple decision contexts in a single decision

### DIFF
--- a/functional-tests/test_api_v1.py
+++ b/functional-tests/test_api_v1.py
@@ -177,8 +177,8 @@ def test_404_for_invalid_product_version(requests_session, greenwave_server, tes
     }
     r = requests_session.post(greenwave_server + 'api/v1.0/decision', json=data)
     assert r.status_code == 404
-    expected = ('Cannot find any applicable policies for koji_build subjects '
-                'at gating point bodhi_push_update_stable in f26')
+    expected = ('Found no applicable policies for koji_build subjects '
+                'at gating point(s) bodhi_push_update_stable in f26')
     assert expected == r.json()['message']
 
 
@@ -193,8 +193,8 @@ def test_404_for_invalid_decision_context(requests_session, greenwave_server, te
     }
     r = requests_session.post(greenwave_server + 'api/v1.0/decision', json=data)
     assert r.status_code == 404
-    expected = ('Cannot find any applicable policies for koji_build subjects '
-                'at gating point bodhi_push_update in fedora-26')
+    expected = ('Found no applicable policies for koji_build subjects '
+                'at gating point(s) bodhi_push_update in fedora-26')
     assert expected == r.json()['message']
 
 

--- a/greenwave/api_v1.py
+++ b/greenwave/api_v1.py
@@ -257,6 +257,25 @@ def make_decision():
            "verbose": true
        }
 
+    **Sample request 3**:
+
+    It is also possible to specify decision_context as a list, so you can query
+    multiple decision contexts at once.
+
+    .. sourcecode:: http
+
+       POST /api/v1.0/decision HTTP/1.1
+       Accept: application/json
+       Content-Type: application/json
+
+       {
+           "decision_context": ["bodhi_update_push_stable", "bodhi_update_push_stable_critpath"],
+           "product_version": "fedora-32",
+           "subject_type": "koji_build",
+           "subject_identifier": "bodhi-5.1.1-1.fc32",
+           "verbose": true
+       }
+
     **Sample On-demand policy request**:
 
     Note: Greenwave would not publish a message on the message bus when an on-demand
@@ -304,10 +323,10 @@ def make_decision():
        }
 
     :jsonparam string product_version: The product version string used for querying WaiverDB.
-    :jsonparam string decision_context: The decision context string, identified by a
-        free-form string label. It is to be named through coordination between policy
+    :jsonparam string decision_context: The decision context(s). Either a string or a list of
+        strings. These are free-form labels to be named through coordination between policy
         author and calling application, for example ``bodhi_update_push_stable``.
-        Do not use this parameter with `rules`.
+        Do not use this parameter together with `rules`.
     :jsonparam string subject_type: The type of software artefact we are
         making a decision about, for example ``koji_build``.
         See :ref:`subject-types` for a list of possible subject types.

--- a/greenwave/policies.py
+++ b/greenwave/policies.py
@@ -826,8 +826,11 @@ class Policy(SafeYAMLObject):
 
         There must be at least one matching rule or no rules in the policy.
         """
-        decision_context = attributes.get('decision_context')
-        if decision_context and (decision_context not in self.all_decision_contexts):
+        decision_contexts = attributes.get('decision_context')
+        if decision_contexts and not isinstance(decision_contexts, list):
+            decision_contexts = [decision_contexts]
+        if decision_contexts and not any(context in self.all_decision_contexts
+                                         for context in decision_contexts):
             return False
 
         product_version = attributes.get('product_version')


### PR DESCRIPTION
When Greenwave was designed we never really envisaged a use for querying multiple decision contexts at once. We assumed it'd only ever make sense to care about exactly one context for whatever decision you're trying to make.

However, we wound up using multiple decision contexts to solve the problem of wanting different policies for the same gating point depending on the contents of the thing being gated. For a specific example, when gating Fedora updates, we have a `bodhi_update_push_testing` context that we always query for any update being pushed to testing, but we also have a `bodhi_update_push_testing_critpath` context that we only query for critical path updates (because it requires some tests that are only *run* on critical path updates). A pending Bodhi pull request - https://github.com/fedora-infra/bodhi/pull/4759 - would make Bodhi query even more decision contexts for critical path updates.

Currently when Bodhi wants to query multiple decision contexts, it has to ask for one decision per context. This is pretty inefficient. It actually turns out to be quite easy to just allow the `decision_context` value to be a list of strings as well as a single string; all that really needs to be done to handle this is a fairly small tweak to `Policy.matches()`. Since we already iterate over every policy, I don't think this even has any significant performance impact, it should be about as fast to check every policy against a list of decision contexts as it is to check it against a single context.

Signed-off-by: Adam Williamson <awilliam@redhat.com>