### PR TITLE
Add a config setting to disable publishing decision updates

### DIFF
--- a/greenwave/config.py
+++ b/greenwave/config.py
@@ -87,6 +87,8 @@ class Config(object):
         "cert_file": "/etc/pki/umb/umb-crt",
         "ca_certs": "/etc/pki/umb/umb-ca",
     }
+    # Whether to publish decision update messages
+    PUBLISH_DECISION_UPDATES = True
 
 
 class ProductionConfig(Config):

--- a/greenwave/consumers/consumer.py
+++ b/greenwave/consumers/consumer.py
@@ -150,6 +150,9 @@ class Consumer:
             product_version,
             publish_testcase):
 
+        if not self.flask_app.config['PUBLISH_DECISION_UPDATES']:
+            return
+
         policy_attributes = dict(
             subject=subject,
             testcase=testcase,

--- a/greenwave/listeners/base.py
+++ b/greenwave/listeners/base.py
@@ -253,6 +253,9 @@ class BaseListener(stomp.ConnectionListener):
         self, submit_time, subject, testcase, product_version, publish_testcase
     ):
 
+        if not self.app.config['PUBLISH_DECISION_UPDATES']:
+            return
+
         policy_attributes = dict(
             subject=subject,
             testcase=testcase,


### PR DESCRIPTION
We no longer use decision update messages in Fedora, but with our current greenwave policies, we publish a whole flood of them, which wastes resources. This will allow us to turn them off.

Signed-off-by: Adam Williamson <awilliam@redhat.com>