### PR TITLE
Allow to match product versions from Koji build target

### DIFF
--- a/conf/subject_types/koji_build.yaml
+++ b/conf/subject_types/koji_build.yaml
@@ -13,3 +13,8 @@ result_queries:
       type: "koji_build,brew-build"
   # {"original_spec_nvr": ITEM}
   - item_key: "original_spec_nvr"
+product_version_from_koji_build_target:
+  - match: '^(rhel-\d+\.\d+).*'
+    product_version: '\1'
+  - match: '^(rhel-\d+).*'
+    product_version: '\1'

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,15 @@
 # SPDX-License-Identifier: GPL-2.0+
-
+import mock
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def set_environment_variable(monkeypatch):
     monkeypatch.setenv('TEST', 'true')
+
+
+@pytest.fixture
+def koji_proxy():
+    mock_proxy = mock.Mock()
+    with mock.patch('greenwave.resources.get_server_proxy', return_value=mock_proxy):
+        yield mock_proxy

--- a/functional-tests/consumers/test_resultsdb.py
+++ b/functional-tests/consumers/test_resultsdb.py
@@ -21,7 +21,7 @@ def create_resultdb_handler(greenwave_server, cache_config=None):
 @mock.patch('greenwave.consumers.consumer.fedora_messaging.api.publish')
 def test_consume_new_result(
         mock_fedora_messaging, requests_session, greenwave_server,
-        testdatabuilder):
+        testdatabuilder, koji_proxy):
     nvr = testdatabuilder.unique_nvr(product_version='fc26')
     result = testdatabuilder.create_result(item=nvr,
                                            testcase_name='dist.rpmdeplint',
@@ -296,7 +296,7 @@ def test_consume_compose_id_result(
 @mock.patch('greenwave.consumers.consumer.fedora_messaging.api.publish')
 def test_consume_legacy_result(
         mock_fedora_messaging, requests_session, greenwave_server,
-        testdatabuilder):
+        testdatabuilder, koji_proxy):
     """ Test that we can still handle the old legacy "taskotron" format.
 
     We should be using resultsdb.result.new everywhere now, but we also

--- a/greenwave/consumers/resultsdb.py
+++ b/greenwave/consumers/resultsdb.py
@@ -12,7 +12,7 @@ to the message bus about the newly satisfied/unsatisfied policy.
 import logging
 
 from greenwave.consumers.consumer import Consumer
-from greenwave.product_versions import subject_product_version
+from greenwave.product_versions import subject_product_versions
 from greenwave.subjects.factory import (
     create_subject_from_data,
     UnknownSubjectDataError,
@@ -126,18 +126,22 @@ class ResultsDBHandler(Consumer):
 
         log.debug('Considering subject: %r', subject)
 
-        product_version = subject_product_version(
+        product_versions = subject_product_versions(
             subject,
             self.koji_base_url,
             brew_task_id,
         )
 
-        log.debug('Guessed product version: %r', product_version)
+        log.debug('Guessed product versions: %r', product_versions)
 
-        self._publish_decision_change(
-            submit_time=submit_time,
-            subject=subject,
-            testcase=testcase,
-            product_version=product_version,
-            publish_testcase=False,
-        )
+        if not product_versions:
+            product_versions = [None]
+
+        for product_version in product_versions:
+            self._publish_decision_change(
+                submit_time=submit_time,
+                subject=subject,
+                testcase=testcase,
+                product_version=product_version,
+                publish_testcase=False,
+            )

--- a/greenwave/listeners/resultsdb.py
+++ b/greenwave/listeners/resultsdb.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0+
 from greenwave.listeners.base import BaseListener
-from greenwave.product_versions import subject_product_version
+from greenwave.product_versions import subject_product_versions
 from greenwave.subjects.factory import (
     create_subject_from_data,
     UnknownSubjectDataError,
@@ -94,19 +94,24 @@ class ResultsDBListener(BaseListener):
 
         self.app.logger.debug("Considering subject: %r", subject)
 
-        product_version = subject_product_version(
+        product_versions = subject_product_versions(
             subject,
             self.koji_base_url,
             brew_task_id,
         )
 
-        self.app.logger.debug("Guessed product version: %r", product_version)
+        self.app.logger.debug("Guessed product versions: %r", product_versions)
 
-        self._publish_decision_change(
-            submit_time=submit_time,
-            subject=subject,
-            testcase=testcase,
-            product_version=product_version,
-            publish_testcase=False,
-        )
+        if not product_versions:
+            product_versions = [None]
+
+        for product_version in product_versions:
+            self._publish_decision_change(
+                submit_time=submit_time,
+                subject=subject,
+                testcase=testcase,
+                product_version=product_version,
+                publish_testcase=False,
+            )
+
         return True

--- a/greenwave/resources.py
+++ b/greenwave/resources.py
@@ -170,10 +170,10 @@ class NoSourceException(RuntimeError):
 
 
 @cached
-def retrieve_koji_build_target(nvr: str, koji_url: str):
-    log.debug('Getting Koji task request ID %r', nvr)
+def retrieve_koji_build_target(task_id, koji_url: str):
+    log.debug('Getting Koji task request ID %r', task_id)
     proxy = _koji(koji_url)
-    task_request = proxy.getTaskRequest(nvr)
+    task_request = proxy.getTaskRequest(task_id)
     if isinstance(task_request, list) and len(task_request) > 1:
         target = task_request[1]
         if isinstance(target, str):

--- a/greenwave/subjects/subject_type.py
+++ b/greenwave/subjects/subject_type.py
@@ -46,6 +46,10 @@ class SubjectType(SafeYAMLObject):
         #   '\1', '\2' etc, expanded to matched groups)
         'product_version_match': SafeYAMLList(item_type=dict, optional=True),
 
+        # Same as product_version_match, but to match build target from Koji
+        # instead of subject ID.
+        'product_version_from_koji_build_target': SafeYAMLList(item_type=dict, optional=True),
+
         # Fixed product version for the subject type used if
         # product_version_match is undefined or does not match subject ID.
         'product_version': SafeYAMLString(optional=True),

--- a/greenwave/tests/conftest.py
+++ b/greenwave/tests/conftest.py
@@ -1,4 +1,4 @@
-import mock
+# SPDX-License-Identifier: GPL-2.0+
 import pytest
 
 from greenwave.app_factory import create_app
@@ -19,10 +19,3 @@ def app():
 @pytest.fixture
 def client(app):
     yield app.test_client()
-
-
-@pytest.fixture
-def koji_proxy():
-    mock_proxy = mock.Mock()
-    with mock.patch('greenwave.resources.get_server_proxy', return_value=mock_proxy):
-        yield mock_proxy

--- a/greenwave/tests/test_product_versions.py
+++ b/greenwave/tests/test_product_versions.py
@@ -5,33 +5,37 @@ import socket
 import pytest
 
 from greenwave import product_versions
+from greenwave.subjects.factory import create_subject
 
 
-@pytest.mark.parametrize('brew_pv, expected_pv', (
-    ('rawhide', 'fedora-rawhide'),
-    ('f35-candidate', 'fedora-35'),
-    ('epel7-candidate', 'epel-7'),
-    ('rhel-8.5.0-candidate', 'rhel-8'),
-    ('rhel-9.0.0-beta-candidate', 'rhel-9'),
+def mock_subject():
+    return create_subject('koji_build', 'nethack-1.2.3-1.rawhide')
+
+
+@pytest.mark.parametrize('brew_pv, expected_pvs', (
+    ('rawhide', ['fedora-rawhide']),
+    ('f35-candidate', ['fedora-35']),
+    ('epel7-candidate', ['epel-7']),
+    ('rhel-8.5.0-candidate', ['rhel-8', 'rhel-8.5']),
+    ('rhel-9.2.0-beta-candidate', ['rhel-9', 'rhel-9.2']),
 ))
-def test_guess_koji_build_product_version(brew_pv, expected_pv, koji_proxy, app):
+def test_guess_koji_build_product_version(brew_pv, expected_pvs, koji_proxy, app):
     koji_proxy.getTaskRequest.return_value = [
         'git://pkgs.devel.example.com/rpms/nethack#12345abcde',
         brew_pv,
         {'scratch': False}]
-    pv = product_versions._guess_koji_build_product_version(
-        brew_pv, 'http://localhost:5006/kojihub', koji_task_id=1)
-    assert pv == expected_pv
+    pvs = product_versions._guess_koji_build_product_versions(
+        mock_subject(), 'http://localhost:5006/kojihub', koji_task_id=1)
+    assert pvs == expected_pvs
 
 
 @pytest.mark.parametrize('task_id', (None, 3))
 def test_guess_koji_build_product_version_socket_error(task_id, koji_proxy, app):
-    subject_identifier = 'release-e2e-test-1.0.1685-1.el5'
     koji_proxy.getBuild.side_effect = koji_proxy.getTaskRequest.side_effect = (
         socket.timeout('timed out')
     )
     expected = 'Could not reach Koji: timed out'
     with pytest.raises(ConnectionError, match=expected):
         # pylint: disable=protected-access
-        product_versions._guess_koji_build_product_version(
-            subject_identifier, 'http://localhost:5006/kojihub', task_id)
+        product_versions._guess_koji_build_product_versions(
+            mock_subject(), 'http://localhost:5006/kojihub', task_id)

--- a/greenwave/tests/test_subjects.py
+++ b/greenwave/tests/test_subjects.py
@@ -34,7 +34,7 @@ def test_subject_create_generic(app):
     assert subject.identifier == subject.item
     assert subject.package_name is None
     assert subject.short_product_version is None
-    assert subject.product_version is None
+    assert subject.product_versions == []
     assert subject.is_koji_build
     assert not subject.supports_remote_rule
 
@@ -68,11 +68,11 @@ def test_subject_to_repr_generic(app):
 
 
 @pytest.mark.parametrize('compose, expected_product_version', (
-    ('RHEL-8.5.0-20210101.d.1', 'rhel-8'),
-    ('RHEL-9.0.0-20210101.d.2', 'rhel-9'),
-    ('FEDORA-2021-35759ad8d3', None),
+    ('RHEL-8.5.0-20210101.d.1', ['rhel-8']),
+    ('RHEL-9.0.0-20210101.d.2', ['rhel-9']),
+    ('FEDORA-2021-35759ad8d3', []),
 ))
 def test_subject_product_version_match(compose, expected_product_version, app):
     subject = create_subject('compose', compose)
     assert subject._type.product_version_match
-    assert subject.product_version == expected_product_version, compose
+    assert subject.product_versions == expected_product_version, compose


### PR DESCRIPTION
There is a new option for subject type definitions that allows Greenwave
to "guess" multiple product versions from Koji build target for given
Koji build.

Example:

    --- !SubjectType
    id: koji_build
    is_koji_build: true
    product_version_from_koji_build_target:
      - match: '^(rhel-\d+\.\d+).*'
        product_version: '\1'
      - match: '^(rhel-\d+).*'
        product_version: '\1'

Multiple product versions can now also be matched from subject
identifier with `product_version_match`.

JIRA: RHELWF-383