### PR TITLE
Fix mypy error

### DIFF
--- a/greenwave/tests/test_listeners.py
+++ b/greenwave/tests/test_listeners.py
@@ -400,7 +400,7 @@ def test_decision_changes(
             },
         ),
         (
-            HTTPError(),
+            HTTPError(),  # type: ignore
             {"policies_satisfied": True},
         ),
     ),


### PR DESCRIPTION
Fixes the following mypy error:

    Argument "request" to "HTTPError" has incompatible type "None"; expected "Request"  [arg-type]