### PR TITLE
Improve error handling

### DIFF
--- a/greenwave/resources.py
+++ b/greenwave/resources.py
@@ -49,6 +49,18 @@ def _requests_timeout():
     return timeout
 
 
+def _raise_for_status(response):
+    if response.ok:
+        return
+
+    msg = (
+        f"Got unexpected status code {response.status_code} for"
+        f" {response.url}: {response.text}"
+    )
+    log.error(msg)
+    raise BadGateway(msg)
+
+
 class BaseRetriever:
     ignore_ids: List[int]
     url: str
@@ -69,7 +81,7 @@ class BaseRetriever:
 
     def _retrieve_data(self, params):
         response = self._make_request(params)
-        response.raise_for_status()
+        _raise_for_status(response)
         return response.json()['data']
 
 
@@ -286,5 +298,5 @@ def retrieve_yaml_remote_rule(url: str):
 
     # remote rule file found...
     response = requests_session.request('GET', url)
-    response.raise_for_status()
+    _raise_for_status(response)
     return response.content

--- a/poetry.lock
+++ b/poetry.lock
@@ -1277,13 +1277,13 @@ files = [
 
 [[package]]
 name = "referencing"
-version = "0.32.0"
+version = "0.32.1"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "referencing-0.32.0-py3-none-any.whl", hash = "sha256:bdcd3efb936f82ff86f993093f6da7435c7de69a3b3a5a06678a6050184bee99"},
-    {file = "referencing-0.32.0.tar.gz", hash = "sha256:689e64fe121843dcfd57b71933318ef1f91188ffb45367332700a86ac8fd6161"},
+    {file = "referencing-0.32.1-py3-none-any.whl", hash = "sha256:7e4dc12271d8e15612bfe35792f5ea1c40970dadf8624602e33db2758f7ee554"},
+    {file = "referencing-0.32.1.tar.gz", hash = "sha256:3c57da0513e9563eb7e203ebe9bb3a1b509b042016433bd1e45a2853466c3dd3"},
 ]
 
 [package.dependencies]
@@ -1310,6 +1310,25 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "requests-mock"
+version = "1.11.0"
+description = "Mock out responses from the requests package"
+optional = true
+python-versions = "*"
+files = [
+    {file = "requests-mock-1.11.0.tar.gz", hash = "sha256:ef10b572b489a5f28e09b708697208c4a3b2b89ef80a9f01584340ea357ec3c4"},
+    {file = "requests_mock-1.11.0-py2.py3-none-any.whl", hash = "sha256:f7fae383f228633f6bececebdab236c478ace2284d6292c6e7e2867b9ab74d15"},
+]
+
+[package.dependencies]
+requests = ">=2.3,<3"
+six = "*"
+
+[package.extras]
+fixture = ["fixtures"]
+test = ["fixtures", "mock", "purl", "pytest", "requests-futures", "sphinx", "testtools"]
 
 [[package]]
 name = "rpds-py"
@@ -2037,4 +2056,4 @@ test = ["flake8", "mock", "pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "36d7ddcd73622ca31e5ed7a3248e86c190e26df8dcd77a1103ad9eae6bd49a7c"
+content-hash = "63982596227d2274a86ab0b54ec4fc420b3c1e6120fd2f6984ec6a0b8addb8df"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ flake8 = {version = "^5.0.4", optional = true}
 pytest = {version = "^7.4.4", optional = true}
 pytest-cov = {version = "^4.1.0", optional = true}
 mock = {version = "^5.1.0", optional = true}
+requests-mock = {version = "^1.11.0", optional = true}
 
 SQLAlchemy = {version = "^2.0.24", optional = true}
 psycopg2-binary = {version = "^2.9.9", optional = true}


### PR DESCRIPTION
Send clear error message to client if an external service request fails and log the error.

Simplifies mocking network requests with requests-mock library.

JIRA: RHELWF-10400