### PR TITLE
Improve error handling for Koji

### DIFF
--- a/greenwave/policies.py
+++ b/greenwave/policies.py
@@ -7,7 +7,6 @@ import os
 import re
 from typing import Optional
 
-from defusedxml.xmlrpc import xmlrpc_client
 from werkzeug.exceptions import BadGateway, BadRequest, NotFound
 from flask import current_app
 
@@ -602,12 +601,10 @@ class RemoteRule(Rule):
         except NotFound:
             error = f'Koji build not found for {subject}'
             return [], [FailedFetchRemoteRuleYaml(subject, remote_policies_urls, error)]
-        except xmlrpc_client.Fault as err:
-            logging.exception('Unexpected Koji XMLRPC fault with code: %s', err.faultCode)
-            error = f'Koji XMLRPC fault due to: \'{err.faultString}\''
-            raise BadGateway(error)
         except greenwave.resources.KojiScmUrlParseError as err:
             return [], [FailedFetchRemoteRuleYaml(subject, remote_policies_urls, err.description)]
+        except BadGateway:
+            raise
         except Exception:
             logging.exception('Failed to retrieve policies for %r', subject)
             error = 'Unexpected error while fetching remote policies'

--- a/greenwave/product_versions.py
+++ b/greenwave/product_versions.py
@@ -9,7 +9,7 @@ import socket
 from typing import List
 
 from defusedxml.xmlrpc import xmlrpc_client
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import BadGateway, NotFound
 
 from greenwave.resources import (
     retrieve_koji_build_target,
@@ -74,8 +74,8 @@ def _guess_koji_build_product_versions(
         return []
     except (xmlrpc_client.ProtocolError, socket.error) as err:
         raise ConnectionError('Could not reach Koji: {}'.format(err))
-    except xmlrpc_client.Fault:
-        log.exception('Unexpected Koji XML RPC fault')
+    except BadGateway:
+        log.warning('Failed to get product version from Koji')
         return []
 
 


### PR DESCRIPTION
Avoid printing stack trace on Koji XMLRPC faults. Log the error and pass it to the client instead.

JIRA: RHELWF-10505, RHELWF-10400