### PR TITLE
Avoid HEAD request, do single GET instead to get gating.yaml

### DIFF
--- a/greenwave/resources.py
+++ b/greenwave/resources.py
@@ -305,15 +305,12 @@ def retrieve_scm_from_koji_build(nvr: str, source: str, koji_url: str):
 @cached
 def retrieve_yaml_remote_rule(url: str):
     """ Retrieve a remote rule file content from the git web UI. """
-    response = requests_session.request('HEAD', url)
+    response = requests_session.request('GET', url)
+
     if response.status_code == 404:
         log.debug('Remote rule not found: %s', url)
         return None
 
-    if response.status_code != 200:
-        raise BadGateway('Error occurred while retrieving a remote rule file from the repo.')
-
-    # remote rule file found...
-    response = requests_session.request('GET', url)
     _raise_for_status(response)
+
     return response.content

--- a/greenwave/tests/test_policies.py
+++ b/greenwave/tests/test_policies.py
@@ -724,7 +724,7 @@ def test_get_sub_policies_multiple_urls(tmpdir, requests_mock):
                 for i in range(1, 3)
             ]
             for url in urls:
-                requests_mock.head(url, status_code=404)
+                requests_mock.get(url, status_code=404)
 
             policy = OnDemandPolicy.create_from_json(serverside_json)
             assert isinstance(policy.rules[0], RemoteRule)
@@ -734,7 +734,7 @@ def test_get_sub_policies_multiple_urls(tmpdir, requests_mock):
             decision = Decision(None, 'fedora-26')
             decision.check(subject, [policy], results)
             request_history = [(r.method, r.url) for r in requests_mock.request_history]
-            assert request_history == [('HEAD', urls[0]), ('HEAD', urls[1])]
+            assert request_history == [('GET', urls[0]), ('GET', urls[1])]
             assert answer_types(decision.answers) == ['missing-gating-yaml']
             assert not decision.answers[0].is_satisfied
             assert decision.answers[0].subject.identifier == subject.identifier

--- a/greenwave/tests/test_retrieve_gating_yaml.py
+++ b/greenwave/tests/test_retrieve_gating_yaml.py
@@ -120,7 +120,7 @@ def test_retrieve_scm_from_build_with_missing_rev(app, koji_proxy):
 
 
 def test_retrieve_yaml_remote_rule_no_namespace(app, requests_mock):
-    requests_mock.head(
+    requests_mock.get(
         'https://src.fedoraproject.org/pkg/raw/deadbeaf/f/gating.yaml', status_code=404)
     # Return 404, because we are only interested in the URL in the request
     # and whether it is correct even with empty namespace.
@@ -132,20 +132,18 @@ def test_retrieve_yaml_remote_rule_no_namespace(app, requests_mock):
 
     request_history = [(r.method, r.url) for r in requests_mock.request_history]
     assert request_history == [(
-        'HEAD', 'https://src.fedoraproject.org/pkg/raw/deadbeaf/f/gating.yaml'
+        'GET', 'https://src.fedoraproject.org/pkg/raw/deadbeaf/f/gating.yaml'
     )]
     assert returned_file is None
 
 
 def test_retrieve_yaml_remote_rule_connection_error(app, requests_mock):
-    requests_mock.head('https://src.fedoraproject.org/pkg/raw/deadbeaf/f/gating.yaml')
     exc = ConnectionError('Something went terribly wrong...')
     requests_mock.get('https://src.fedoraproject.org/pkg/raw/deadbeaf/f/gating.yaml', exc=exc)
 
     expected_error = re.escape(
         'Got unexpected status code 502 for'
-        ' https://src.fedoraproject.org/pkg/raw/deadbeaf/f/gating.yaml:'
-        ' {"message": "Something went terribly wrong..."}'
+        ' https://src.fedoraproject.org/pkg/raw/deadbeaf/f/gating.yaml'
     )
     with pytest.raises(BadGateway, match=expected_error):
         retrieve_yaml_remote_rule(


### PR DESCRIPTION
This may save quite a lot of time even thought the 404 GET response may contain a lot of unneeded HTML.

It may also serve as a workaround for dist-git-cgit sometimes not responding to HEAD requests.

JIRA: RHELWF-10541