### PR TITLE
Make listener debug logs less verbose

### DIFF
--- a/greenwave/tests/test_listeners.py
+++ b/greenwave/tests/test_listeners.py
@@ -385,6 +385,7 @@ def test_decision_changes(
     (
         (
             {
+                "summary": "1 of 1 test results failed",
                 "policies_satisfied": False,
                 "satisfied_requirements": [],
                 "unsatisfied_requirements": [
@@ -392,6 +393,7 @@ def test_decision_changes(
                 ],
             },
             {
+                "summary": "1 of 1 test results failed",
                 "policies_satisfied": False,
                 "satisfied_requirements": [],
                 "unsatisfied_requirements": [


### PR DESCRIPTION
Logging whole decisions and messages could be useful but is very difficult to debug such large logs.