### PR TITLE
Remove subject_type attribute supports_remote_rule

### DIFF
--- a/conf/subject_types/brew-build-group.yaml
+++ b/conf/subject_types/brew-build-group.yaml
@@ -1,3 +1,0 @@
---- !SubjectType
-id: brew-build-group
-supports_remote_rule: true

--- a/conf/subject_types/koji_build.yaml
+++ b/conf/subject_types/koji_build.yaml
@@ -4,7 +4,6 @@ aliases:
   - brew-build
 is_koji_build: true
 is_nvr: true
-supports_remote_rule: true
 item_key: "original_spec_nvr"
 result_queries:
   # {"type": "koji_build,brew-build", "item": ITEM}

--- a/conf/subject_types/redhat-container-image.yaml
+++ b/conf/subject_types/redhat-container-image.yaml
@@ -3,7 +3,6 @@ id: redhat-container-image
 product_version: rhel-8
 is_koji_build: true
 is_nvr: true
-supports_remote_rule: true
 item_key: "nvr"
 result_queries:
   - item_key: "nvr"

--- a/conf/subject_types/redhat-module.yaml
+++ b/conf/subject_types/redhat-module.yaml
@@ -1,4 +1,3 @@
 --- !SubjectType
 id: redhat-module
 product_version: rhel-8
-supports_remote_rule: true

--- a/docs/decision_requirements.rst
+++ b/docs/decision_requirements.rst
@@ -160,9 +160,9 @@ To waive this, use the test case name "invalid-gating-yaml".
 Missing remote rule
 -------------------
 
-If the requested policy contains a ``RemoteRule`` with ``required`` attribute
-set to ``true``, this unsatisfied requirement is created for each subject that
-supports remote rule files and the file is missing for requested subject.
+This unsatisfied requirement is created if the requested policy contains a
+``RemoteRule`` with ``required`` attribute set to ``true`` but the remote file
+is missing.
 
 To waive this, use test case name "missing-gating-yaml".
 

--- a/functional-tests/test_api_v1.py
+++ b/functional-tests/test_api_v1.py
@@ -1661,7 +1661,6 @@ def test_installed_subject_types(requests_session, greenwave_server):
     assert len(data['subject_types'])
     assert [x['id'] for x in data['subject_types']] == [
         'bodhi_update',
-        'brew-build-group',
         'compose',
         'koji_build',
         'redhat-container-image',

--- a/greenwave/policies.py
+++ b/greenwave/policies.py
@@ -583,9 +583,6 @@ class RemoteRule(Rule):
         and answers (including FetchedRemoteRuleYaml, MissingRemoteRuleYaml,
         InvalidRemoteRuleYaml, FailedFetchRemoteRuleYaml).
         """
-        if not subject.supports_remote_rule:
-            return [], []
-
         remote_policies_urls = []
         remote_policies_url = None
         response = None

--- a/greenwave/subjects/subject.py
+++ b/greenwave/subjects/subject.py
@@ -90,10 +90,6 @@ class Subject:
         return self.subject_type.is_koji_build
 
     @property
-    def supports_remote_rule(self):
-        return self.subject_type.supports_remote_rule
-
-    @property
     def ignore_missing_policy(self):
         return self.subject_type.ignore_missing_policy
 

--- a/greenwave/subjects/subject_type.py
+++ b/greenwave/subjects/subject_type.py
@@ -34,9 +34,6 @@ class SubjectType(SafeYAMLObject):
         # version can be parsed for identifier.
         'is_nvr': SafeYAMLBool(optional=True),
 
-        # Subject type can be used with RemoteRule only if value is True.
-        'supports_remote_rule': SafeYAMLBool(optional=True, default=False),
-
         # Omit responding with HTTP 404 if there is no applicable policy.
         'ignore_missing_policy': SafeYAMLBool(optional=True, default=False),
 

--- a/greenwave/tests/test_api_v1.py
+++ b/greenwave/tests/test_api_v1.py
@@ -294,7 +294,6 @@ def test_subject_types(client):
     assert len(data['subject_types'])
     assert [x['id'] for x in data['subject_types']] == [
         'bodhi_update',
-        'brew-build-group',
         'compose',
         'koji_build',
         'redhat-container-image',

--- a/greenwave/tests/test_subjects.py
+++ b/greenwave/tests/test_subjects.py
@@ -36,7 +36,6 @@ def test_subject_create_generic(app):
     assert subject.short_product_version is None
     assert subject.product_versions == []
     assert subject.is_koji_build
-    assert not subject.supports_remote_rule
 
 
 def test_subject_koji_build_result_queries(app):

--- a/greenwave/tests/test_subjects_type.py
+++ b/greenwave/tests/test_subjects_type.py
@@ -18,7 +18,6 @@ def test_subject_type_create(subject_types):
     assert subject_type.aliases == ['brew-build']
     assert subject_type.is_koji_build
     assert subject_type.is_nvr
-    assert subject_type.supports_remote_rule
     assert subject_type.item_key == 'original_spec_nvr'
 
 


### PR DESCRIPTION
Currently, setting `supports_remote_rule` or setting it to `false` means that any `RemoteRule` (even with specified sources/URLs) in policies is ignored for that subject type. In most cases, this is confusing unexpected behavior.

The change is to drop the attribute completely and rely on presence of `RemoteRule` in policies (it should not be present if the subject type the policy uses does not support it).

JIRA: RHELWF-10561