### PR TITLE
Update dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1414,13 +1414,13 @@ testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygm
 
 [[package]]
 name = "pytest-cov"
-version = "4.1.0"
+version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
-    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
 ]
 
 [package.dependencies]
@@ -1428,7 +1428,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "python-dateutil"
@@ -2294,4 +2294,4 @@ test = ["flake8", "mock", "pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "3cd4ab5be4d9e503addcb2158990fbe4690399428092655643a8f7cc637472b6"
+content-hash = "528f2a267081a4d6099bd427781651d4792cef070825ffeec0a7fc0a80a55b2e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ fedora-messaging = "^3.4.1"
 
 flake8 = {version = "^5.0.4", optional = true}
 pytest = {version = "^8.0.2", optional = true}
-pytest-cov = {version = "^4.1.0", optional = true}
+pytest-cov = {version = "^5.0.0", optional = true}
 mock = {version = "^5.1.0", optional = true}
 requests-mock = {version = "^1.11.0", optional = true}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wheel==0.42.0
 pip==24.0
-setuptools==69.1.1
+setuptools==69.2.0


### PR DESCRIPTION
Bump pytest-cov from 4.1.0 to 5.0.0

Bumps [pytest-cov](https://github.com/pytest-dev/pytest-cov) from 4.1.0 to 5.0.0.
- [Changelog](https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest-cov/compare/v4.1.0...v5.0.0)

---
updated-dependencies:
- dependency-name: pytest-cov dependency-type: direct:production update-type: version-update:semver-major ...



Bump setuptools from 69.1.1 to 69.2.0

Bumps [setuptools](https://github.com/pypa/setuptools) from 69.1.1 to 69.2.0.
- [Release notes](https://github.com/pypa/setuptools/releases)
- [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
- [Commits](https://github.com/pypa/setuptools/compare/v69.1.1...v69.2.0)

---
updated-dependencies:
- dependency-name: setuptools dependency-type: direct:production update-type: version-update:semver-minor ...