### PR TITLE
Retry on Koji TimeoutError and drop http support

### DIFF
--- a/greenwave/config.py
+++ b/greenwave/config.py
@@ -45,6 +45,8 @@ class Config:
     }
     REMOTE_RULE_GIT_TIMEOUT = 30
     KOJI_BASE_URL = "https://koji.fedoraproject.org/kojihub"
+    KOJI_TIMEOUT = 15
+    KOJI_RETRY = 3
     # Options for outbound HTTP requests made by python-requests
     REQUESTS_TIMEOUT = (6.1, 15)
     REQUESTS_VERIFY = True

--- a/greenwave/resources.py
+++ b/greenwave/resources.py
@@ -37,7 +37,9 @@ def _koji(uri: str):
     try:
         return data.koji_server_proxy_cache
     except AttributeError:
-        proxy = get_server_proxy(uri, _requests_timeout())
+        timeout = current_app.config["KOJI_TIMEOUT"]
+        retry = current_app.config["KOJI_RETRY"]
+        proxy = get_server_proxy(uri, timeout=timeout, retry=retry)
         data.koji_server_proxy_cache = proxy
         return proxy
 

--- a/greenwave/xmlrpc_server_proxy.py
+++ b/greenwave/xmlrpc_server_proxy.py
@@ -3,12 +3,16 @@
 Provides an "xmlrpc_client.ServerProxy" object with a timeout on the socket.
 """
 
-import urllib.parse
+import logging
 
 from defusedxml.xmlrpc import xmlrpc_client
+from opentelemetry import trace
+
+log = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
-def get_server_proxy(uri, timeout):
+def get_server_proxy(uri, *, timeout, retry) -> xmlrpc_client.ServerProxy:
     """
     Create an :py:class:`xmlrpc_client.ServerProxy` instance with a socket timeout.
 
@@ -22,32 +26,27 @@ def get_server_proxy(uri, timeout):
         xmlrpc_client.ServerProxy: An instance of :py:class:`xmlrpc_client.ServerProxy` with
             a socket timeout set.
     """
-    parsed_uri = urllib.parse.urlparse(uri)
-    if parsed_uri.scheme == "https":
-        transport = SafeTransport(timeout=timeout)
-    else:
-        transport = Transport(timeout=timeout)
-
+    transport = SafeTransport(timeout=timeout, retry=retry)
     return xmlrpc_client.ServerProxy(uri, transport=transport, allow_none=True)
 
 
-class Transport(xmlrpc_client.Transport):
-    def __init__(self, *args, timeout=None, **kwargs):  # pragma: no cover
-        super().__init__(*args, **kwargs)
-        self._timeout = timeout
-
-    def make_connection(self, host):  # pragma: no cover
-        connection = super().make_connection(host)
-        connection.timeout = self._timeout
-        return connection
-
-
 class SafeTransport(xmlrpc_client.SafeTransport):
-    def __init__(self, *args, timeout=None, **kwargs):  # pragma: no cover
+    def __init__(self, *args, timeout=None, retry=3, **kwargs):
         super().__init__(*args, **kwargs)
         self._timeout = timeout
+        self._retry = retry
 
-    def make_connection(self, host):  # pragma: no cover
+    def make_connection(self, host):
         connection = super().make_connection(host)
         connection.timeout = self._timeout
         return connection
+
+    @tracer.start_as_current_span("request")
+    def request(self, *args, **kwargs):
+        for attempt in range(1, self._retry + 1):
+            try:
+                return super().request(*args, **kwargs)
+            except TimeoutError:
+                log.warning("Retrying on XMLRPC timeout (attempt=%s)", attempt)
+
+        return super().request(*args, **kwargs)


### PR DESCRIPTION
Adds separate options to specify timeout and retry for the XMLRPC connections (`KOJI_TIMEOUT`, `KOJI_RETRY`).

Adds tracing for XMLRPC requests.

Drops unused support for http protocol for the XMLRPC connection.

JIRA: RHELWF-11696