### PR TITLE
Support multiple subject types

### DIFF
--- a/docs/package-specific-policies.rst
+++ b/docs/package-specific-policies.rst
@@ -23,29 +23,34 @@ Here is an example :file:`gating.yaml` file:
    product_versions:
      - fedora-*
    decision_context: bodhi_update_push_testing
-   subject_type: koji_build
+   subject_types:
+     - koji_build
+     - bodhi_update
    rules:
      - !PassingTestCaseRule {test_case_name: org.centos.prod.ci.pipeline.allpackages-build.package.test.functional.complete}
+
    --- !Policy
    product_versions:
      - fedora-*
    decision_context: bodhi_update_push_stable
-   subject_type: koji_build
+   subject_types:
+     - koji_build
+     - bodhi_update
    rules:
      - !PassingTestCaseRule {test_case_name: org.centos.prod.ci.pipeline.allpackages-build.package.test.functional.complete}
 
 The structure of the file is the same as the policies in Greenwave's
 configuration, with the only difference that the "id" key is optional.
 
-``product_versions``, ``decision_context`` and ``subject_type`` in the
-:file:`gating.yaml` file should match with the defined values in the global
-policy defined in the Greenwave conf that contains the ``RemoteRule``
-that will enable this check. If ``product_versions`` are not specified
-in the remote :file:`gating.yaml`, values from the global policy will be used.
+If set, ``product_versions``, ``decision_contexts`` (or single
+``decision_context``) and ``subject_types`` (or single ``subject_type``) in the
+:file:`gating.yaml` file should match the values defined in the parent global
+policy defined in the Greenwave configuration that contains the ``RemoteRule``.
 
-The ``subject_type`` should always be defined and the permitted values are
-``koji_build``, ``redhat-module`` and ``redhat-container-image``.
-If no ``subject_type`` will be specified the default value is ``koji_build``.
+If neither ``subject_types`` nor ``subject_type`` are defined, subject types
+from the parent global policy are used instead. Similarly, product versions
+from the parent global policy are used as default if ``product_versions`` is
+undefined.
 
 Refer to :doc:`policies` for details about each of the keys in the YAML file.
 

--- a/docs/policies.rst
+++ b/docs/policies.rst
@@ -23,7 +23,7 @@ Greenwave policies need the following parameters:
 
 - decision_contexts
 - product_versions
-- subject_type
+- subject_types
 - rules
 - id
 
@@ -98,7 +98,7 @@ The document is a map (dictionary) with the following keys:
 
 .. _subject_type:
 
-``subject_type``
+``subject_types`` (list) or ``subject_type`` (single value)
    When you ask Greenwave for a decision, you ask it about a specific software
    artefact (the "subject" of the decision). Each policy applies to some type
    of software artefact -- in this example, the policy applies to Bodhi
@@ -336,7 +336,9 @@ Here's an example of a RemoteRule:
    product_versions:
      - fedora-29
    decision_contexts: [osci_compose_gate]
-   subject_type: koji_build
+   subject_types:
+     - koji_build
+     - bodhi_update
    excluded_packages: []
    rules:
      - !RemoteRule {}


### PR DESCRIPTION
Adds `subject_types` field as an alternative to `subject_type`. One of these must be defined in all policies. In remote policies, these are optional as before.

Also fixes matching the `subject_type` in remote policies. Apparently, the value was never used before.

Fixes: https://pagure.io/greenwave/issue/609

JIRA: RHELWF-2419