### PR TITLE
Exclude semgrep minimum release age rule for Renovate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,6 @@ ci:
   autoupdate_schedule: monthly
   skip:
     - hadolint-docker
-    # renovate exceeds tier max size 250MiB on pre-commit.ci
-    # (due to huge node.js dependencies)
-    - renovate-config-validator
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -82,9 +79,3 @@ repos:
     rev: v2.14.0
     hooks:
       - id: hadolint-docker
-
-  # renovate.json validator
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 43.245.0
-    hooks:
-      - id: renovate-config-validator

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,8 @@ commands =
     uvx --with semgrep \
     semgrep scan --config=auto --error \
         --exclude-rule=python.lang.security.insecure-uuid-version.insecure-uuid-version \
+        # Our shared Renovate bot preset already enforces minimumReleaseAge (3 days).
+        --exclude-rule=package_managers.renovate.renovate-missing-minimum-release-age.renovate-missing-minimum-release-age \
         --exclude=docker-compose.yml \
         --exclude=".*" \
         {posargs}


### PR DESCRIPTION
Our shared Renovate bot preset already enforces minimumReleaseAge.

Assisted-by: Claude Opus 4.6 (Anthropic)

---

Drop slow unnecessary pre-commit hook, handled by MintMaker