### PR TITLE
Replace redundant pre-commit hooks with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,45 +17,14 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  # Sort imports
-  - repo: https://github.com/pycqa/isort
-    rev: 9.0.0b1
-    hooks:
-      - id: isort
-        name: isort
-        args:
-          - --line-length=79
-          - --profile=black
-
-  # Remove unused imports, variables, statements
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.3.3
-    hooks:
-      - id: autoflake
-
-  # Auto-update syntax
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
-        args:
-          - --py311-plus
-
   # Linter and formatter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1
     hooks:
       - id: ruff
         args:
-          # ignore: E501 Line too long
-          - --ignore=E501
+          - --fix
       - id: ruff-format
-
-  # Linter and formatter
-  - repo: https://github.com/Instagram/Fixit
-    rev: v2.2.1
-    hooks:
-      - id: fixit-fix
 
   # Type linter
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,5 +74,6 @@ include = [
 ]
 
 [tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP"]
 # RUF012: too noisy for Flask config and SafeYAML classes (https://github.com/astral-sh/ruff/issues/5243)
-ignore = ["RUF012"]
+ignore = ["E501", "RUF012"]


### PR DESCRIPTION
Ruff natively handles import sorting (I), unused imports (F401), and Python upgrade rules (UP), making these separate hooks redundant. It reads requires-python from pyproject.toml for the target version.

Assisted-by: Claude (Anthropic)