### PR TITLE
Add yamllint, codespell, zizmor, and actionlint pre-commit hooks

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -9,6 +9,9 @@ name: Gating
   workflow_dispatch:
     inputs: {}
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Unit tests
@@ -19,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -48,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -67,6 +74,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
@@ -85,6 +94,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,28 @@ repos:
     rev: v2.15.1
     hooks:
       - id: hadolint-docker
+
+  # YAML linter
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+
+  # Spell checker
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+
+  # GitHub Actions linters
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+      - id: zizmor
+        args:
+          - --min-severity=low
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    indent-sequences: whatever
+  line-length: disable
+  truthy:
+    check-keys: false

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -254,7 +254,7 @@ Greenwave 1.4.1
 Released 11 November 2019
 
 * Greenwave now using ``extra->source->original_url`` field instead of just ``source``
-  field to retreive SCM information from Koji build.
+  field to retrieve SCM information from Koji build.
   If there is no ``source`` nor ``extra->source->original_url`` field, other rules
   are still being checked.
 * Added support for the ``redhat-container-image`` subject type. This type is now
@@ -345,7 +345,7 @@ Released 15 May 2019
   waivers IDs lists to ignore (``ignore_result``, ``ignore_waiver``). These are used to compare
   the new decision with older one. In case of multiple new results or waivers there could be a race
   condition. This change introduces new parameters results_since and waivers_since, used to
-  determin the decision before these specific dates. This solves the race conditions.
+  determine the decision before these specific dates. This solves the race conditions.
   ``ignore_result`` and ``ignore_waiver`` are not used anymore to gather the old decision, but they
   are still parameters of the API for backwards compatibility.
 * Add support for on-demand policies: enhancing the ``/decision`` endpoint API to allow a new parameter
@@ -387,7 +387,7 @@ Released 04 February 2019
 
 * Replace PackageSpecificBuild with a packages whitelist on the policy.
   Also deprecating the key "blacklist" and introduced instead ``excluded_packages``:
-  unifing these mechanisms and tweak the terminology to be a little more
+  unifying these mechanisms and tweak the terminology to be a little more
   consistent and self-describing.
   The plan is to support "blacklist" for the next 4 months and then stop
   supporting it completely.
@@ -568,7 +568,7 @@ Greenwave 0.9.2
 
 Released 06 August 2018.
 
-* Small code improvement: removed unsed variable.
+* Small code improvement: removed unused variable.
 
 * Fixed retrieving old decisions when publishing a new message about a
   decision change (when received a message about a new result) and

--- a/greenwave/consumers/fedora_messaging_consumer.py
+++ b/greenwave/consumers/fedora_messaging_consumer.py
@@ -5,7 +5,7 @@ The fedora-messaging consumer.
 This module is responsible consuming messages sent to the fedora message bus via
 fedora-messaging.
 It will get all the messages and pass them onto their appropriate base consumers
-to re-use the same code path.
+to reuse the same code path.
 """
 
 import logging

--- a/greenwave/product_versions.py
+++ b/greenwave/product_versions.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 def _product_version_number_or_none(toparse) -> int | None:
-    # seperate the prefix from the number
+    # separate the prefix from the number
     result = list(filter(None, "-".join(re.split(r"(\d+)", toparse)).split("-")))
     if len(result) >= 2:
         try:

--- a/greenwave/safe_yaml.py
+++ b/greenwave/safe_yaml.py
@@ -148,7 +148,7 @@ class SafeYAMLDateTime(SafeYAMLAttribute):
 
 class SafeYAMLList(SafeYAMLAttribute):
     """
-    YAML object attribute represeting a list of values.
+    YAML object attribute representing a list of values.
     """
 
     def __init__(self, item_type, default_factory: Callable[[], list] = list, **kwargs):

--- a/greenwave/utils.py
+++ b/greenwave/utils.py
@@ -122,7 +122,7 @@ def load_config(config_obj=None):
 
 
 def insert_headers(response):
-    """Insert the CORS headers for the give reponse if there are any
+    """Insert the CORS headers for the give response if there are any
     configured for the application.
     """
     if current_app.config.get("CORS_URL"):

--- a/openshift/greenwave-test-template.yaml
+++ b/openshift/greenwave-test-template.yaml
@@ -19,7 +19,7 @@ parameters:
   required: true
 - name: GREENWAVE_IMAGE
   displayName: Greenwave container image
-  description: Image to be used for Greenwave deployement
+  description: Image to be used for Greenwave deployment
   value: 172.30.1.1:5000/myproject/greenwave:latest
   required: true
 - name: GREENWAVE_SECRET_KEY


### PR DESCRIPTION
Add missing linter hooks and fix issues they found:
- yamllint with lenient indentation config
- codespell for spell checking
- zizmor and actionlint for GitHub Actions workflows
- Fix typos found by codespell
- Add persist-credentials: false to checkout actions
- Add permissions block to GitHub Actions workflow

Assisted-by: Claude (Anthropic)