### PR TITLE
Remove bandit tox env and unnecessary bandit args

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,16 +45,6 @@ commands =
         --cov-report=html \
         {posargs}
 
-[testenv:bandit]
-commands =
-    uvx --with bandit \
-    bandit \
-        # B113:request_without_timeout is broken:
-        # https://github.com/PyCQA/bandit/issues/996
-        --skip B113 \
-        --exclude functional-tests,greenwave/tests \
-        --recursive greenwave
-
 [testenv:semgrep]
 commands =
     uvx --with semgrep \


### PR DESCRIPTION
Remove the bandit tox env superseded by the pre-commit hook. Remove --skip=B113 from bandit pre-commit hook (not needed). Move hadolint to end of pre-commit config to prevent its docker dependency from blocking other hooks.

Assisted-by: Claude (Anthropic)